### PR TITLE
set HookURL parameter to NoEcho

### DIFF
--- a/slack-notifier/cfn-templates/slack-notifier.yml
+++ b/slack-notifier/cfn-templates/slack-notifier.yml
@@ -7,6 +7,7 @@ Parameters:
   HookURL:
     Type: String
     Description: 'Please enter the web hook url from Slack:'
+    NoEcho: true
 Resources:
   LambdaFunctionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
The HookURL contains a form of auth information and should be hidden.