### PR TITLE
Update sms-notifier.yml to use nodejs 8.10 so that it can be deployed.

### DIFF
--- a/sms-notifier/sms-notifier.yml
+++ b/sms-notifier/sms-notifier.yml
@@ -102,7 +102,7 @@ Resources:
                 callback(null, snsPublishSuccessMessage); //return success
               });
           };
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
 
   AwsHealthEventRule:
     Type: AWS::Events::Rule

--- a/sms-notifier/testHeatlhEvent.json
+++ b/sms-notifier/testHeatlhEvent.json
@@ -1,0 +1,22 @@
+{
+  "version": "0",
+  "id": "7bf73129-1428-4cd3-a780-95db273d1602",
+  "detail-type": "AWS Health Event",
+  "source": "aws.health",
+  "account": "123456789012",
+  "time": "2016-06-05T06:27:57Z",
+  "region": "us-east-1",
+  "resources": [],
+  "detail": {
+    "eventArn": "arn:aws:health:us-east-1::event/AWS_HEALTH_TEST_ALERT",
+    "service": "AWS_EC2",
+    "eventTypeCode": "AWS_EC2_HEALTH_TEST_EVENT",
+    "eventTypeCategory": "category",
+    "startTime": "Sun, 05 Jun 2016 05:01:10 GMT",
+    "endTime": "Sun, 05 Jun 2016 05:30:57 GMT",
+    "eventDescription": [{
+      "language": "en_US",
+      "latestDescription": "something is wrong"
+    }]
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
updated sms-notifier/sms-notifier.yml to nodejs8.10
added test health event for users to validate lambda function (https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/EventTypes.html#health-event-types)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.