### PR TITLE
Adding encoding of POST data

### DIFF
--- a/shd-notifier/Health-Event-Chat-Post-LambdaFn.py
+++ b/shd-notifier/Health-Event-Chat-Post-LambdaFn.py
@@ -81,7 +81,7 @@ def chatMessage(message, subject, webhook, type):
     logger.info(str(chat_message))
     # post the message, catch and log any errors
     header = {'Content-type': 'application/json'}
-    req = Request(webhook, json.dumps(chat_message), header)
+    req = Request(webhook, json.dumps(chat_message).encode('utf8'), header)
     try:
         response = urlopen(req)
         response.read()


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-health-tools/issues/66

*Description of changes:* Added UTF-8 encoding to POST data of the Request object to be passed to urlopen. UTF-8 encoding used as Health events may contain non-ascii characters.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
