### PR TITLE
AWS Health API high availability endpoint demo code

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Setup and usage instructions are present for each tool in its respective directo
 [AWS Health AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED triggers freeing up of unused ENIs](automated-actions/AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED/) <br />
 [AWS Health AWS_RISK_CREDENTIALS_EXPOSED remediation](automated-actions/AWS_RISK_CREDENTIALS_EXPOSED/) <br />
 [AWS Health AWS_EBS_VOLUME_LOST Remediation](automated-actions/AWS_EBS_VOLUME_LOST/) <br />
+#### Demos:
+[AWS Health API high availability endpoint](high-availability-endpoint/) <br />
 
 ![Architecture](images/AWSHealthToolsArchitecture.jpg)
 

--- a/high-availability-endpoint/.gitignore
+++ b/high-availability-endpoint/.gitignore
@@ -1,0 +1,12 @@
+# java demo
+java/.gradle/
+java/build
+java/buildSrc/build/
+java/gradle/
+java/gradlew
+java/gradlew.bat
+java/wrapper/
+
+# python demo
+python/v-aws-health-env
+python/__pycache__

--- a/high-availability-endpoint/README.md
+++ b/high-availability-endpoint/README.md
@@ -5,7 +5,7 @@ This repository contains sample code for using the AWS Health API's high availab
 
 ## Background
 
-AWS Health is a RESTful web service that uses HTTPS as a transport and JSON as a message serialization format. Your application code can make requests directly to the AWS Health API. When using the REST API directly, you must write the necessary code to sign and authenticate your requests. For more information, see the [AWS Health API Reference](https://alpha-docs-aws.amazon.com/health/latest/APIReference/).
+AWS Health is a RESTful web service that uses HTTPS as a transport and JSON as a message serialization format. Your application code can make requests directly to the AWS Health API. When using the REST API directly, you must write the necessary code to sign and authenticate your requests. For more information, see the [AWS Health API Reference](https://docs.aws.amazon.com/health/latest/APIReference/).
 
 **NOTE**: You must have a Business or Enterprise support plan from [AWS Support](http://aws.amazon.com/premiumsupport/) to use the AWS Health API. If you call the AWS Health API from an AWS account that doesn't have a Business or Enterprise support plan, you receive a ```SubscriptionRequiredException``` error. 
 

--- a/high-availability-endpoint/README.md
+++ b/high-availability-endpoint/README.md
@@ -1,0 +1,53 @@
+high-availability-endpoint
+--------------------------
+
+This repository contains sample code for using the AWS Health API's high availability endpoint to determine which region to connect to in order to get the latest Health information.
+
+## Background
+
+AWS Health is a RESTful web service that uses HTTPS as a transport and JSON as a message serialization format. Your application code can make requests directly to the AWS Health API. When using the REST API directly, you must write the necessary code to sign and authenticate your requests. For more information, see the [AWS Health API Reference](https://alpha-docs-aws.amazon.com/health/latest/APIReference/).
+
+**NOTE**: You must have a Business or Enterprise support plan from [AWS Support](http://aws.amazon.com/premiumsupport/) to use the AWS Health API. If you call the AWS Health API from an AWS account that doesn't have a Business or Enterprise support plan, you receive a ```SubscriptionRequiredException``` error. 
+
+You can simplify application development by using the AWS SDKs that wrap the AWS Health REST API calls. You provide your credentials, and then these libraries take care of authentication and request signing. 
+AWS Health also provides a Personal Health Dashboard in the AWS Management Console that you can use to view and search for events and affected entities.
+
+## Endpoints
+
+The AWS Health API follows a [multi-Region application architecture](http://aws.amazon.com/solutions/implementations/multi-region-application-architecture/) and has two regional endpoints in an active-passive configuration. To support active-passive DNS failover, AWS Health provides a single, global endpoint. You can determine the active endpoint and corresponding signing Region by performing a DNS lookup on the global endpoint. This lets you know which endpoint to use in your code so that you can get the latest information from AWS Health. 
+
+When you make a request to the global endpoint, you must specify your AWS access credentials to the regional endpoint that you target and configure the signing for your Region. Otherwise, your authentication might fail. For more information, see [Signing AWS Health API requests](https://docs.aws.amazon.com/health/latest/ug/health-api.html#signing). 
+
+The following table represents the default configuration.
+
+| Description | Signing Region | Endpoint | Protocol |
+| ----------- | -------------- | -------- | -------- |
+| Active | 	us-east-1 |	health.us.east-1.amazonaws.com | HTTPS |
+| Passive | us-east-2 | health.us-east-2.amazonaws.com | HTTPS |
+| Global | us-east-1 This is the signing Region of the current active endpoint. | global.health.amazonaws.com | HTTPS |
+
+For China regions see [this configuration](https://docs.amazonaws.cn/en_us/health/latest/ug/health-api.html#endpoints).
+
+The method to determine if an endpoint is the _active endpoint_ is to do a DNS lookup on the _global endpoint CNAME_ and extract the region from the resolved name.
+
+For example, the following command completes a DNS lookup on the global.health.amazonaws.com endpoint. The command then returns the us-east-1 Region endpoint:
+
+```
+$ dig global.health.amazonaws.com | grep CNAME
+global.health.amazonaws.com. 10	IN	CNAME	health.us-east-1.amazonaws.com
+```
+
+The active endpoint region is us-east-1.
+
+Both the active and passive endpoints will return AWS Health data. However, the latest AWS Health data will only be available from the active endpoint. Data from the passive endpoint will be eventually consistent. We recommend that you **restart any workflows when the active endpoint changes**.
+
+## Demos
+
+For examples on using the high availability endpoint with the AWS SDKs see:
+
+* [Java demo](java/)
+* [Python demo](python/)
+
+## License
+
+AWS Health Tools are licensed under the Apache 2.0 License

--- a/high-availability-endpoint/java/README.md
+++ b/high-availability-endpoint/java/README.md
@@ -1,0 +1,101 @@
+## Using the high availability endpoint java demo
+
+To build and run this demo:
+
+1. Download / clone the repo [AWS Health high availability endpoint demo](https://github.com/aws/aws-health-tools/high-availability-endpoint) from GitHub
+
+2. [Install Gradle](https://docs.gradle.org/current/userguide/installation.html)
+
+3. Navigate to the java demo project directory in a command line window:
+
+```
+cd java
+```
+
+4. Compile the demo by entering the following command:
+
+```
+gradle build
+```
+
+5. Set the AWS credentials:
+
+[Configure AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html). e.g. using profiles or environment variables
+
+```
+export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
+export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+export AWS_SESSION_TOKEN="your-aws-token"
+```
+
+6. Enter the following command to run the demo:
+
+```
+gradle run
+```
+
+The output will look something like:
+
+```
+> Task :run
+[main] INFO aws.health.high.availability.endpoint.demo.HighAvailabilityV2Workflow - EventDetails(Event=Event(Arn=arn:aws:health:global::event/CONFIG/AWS_CONFIG_OPERATIONAL_NOTIFICATION/AWS_CONFIG_OPERATIONAL_NOTIFICATION_88a43e8a-e419-4ca7-9baa-56bcde4dba3, Service=CONFIG, EventTypeCode=AWS_CONFIG_OPERATIONAL_NOTIFICATION, EventTypeCategory=accountNotification, Region=global, StartTime=2020-09-11T02:55:49.899Z, LastUpdatedTime=2020-09-11T03:46:31.764Z, StatusCode=open, EventScopeCode=ACCOUNT_SPECIFIC), EventDescription=EventDescription(LatestDescription=As part of our ongoing efforts to optimize costs associated with recording changes related to certain ephemeral workloads, AWS Config is scheduled to release an update to relationships modeled within ConfigurationItems (CI) for 7 EC2 resource types on August 1, 2021. Examples of ephemeral workloads include changes to Amazon Elastic Compute Cloud (Amazon EC2) Spot Instances, Amazon Elastic MapReduce jobs, and Amazon EC2 Autoscaling. This update will optimize CI models for EC2 Instance, SecurityGroup, Network Interface, Subnet, VPC, VPN Gateway, and Customer Gateway resource types to record direct relationships and deprecate indirect relationships.
+
+A direct relationship is defined as a one-way relationship (A->B) between a resource (A) and another resource (B), and is typically derived from the Describe API response of resource (A). An indirect relationship, on the other hand, is a relationship that AWS Config infers (B->A), in order to create a bidirectional relationship. For example, EC2 instance -> Security Group is a direct relationship, since security groups are returned as part of the describe API response for an EC2 instance. But Security Group -> EC2 instance is an indirect relationship, since EC2 instances are not returned when describing an EC2 Security group.
+
+Until now, AWS Config has recorded both direct and indirect relationships. With the launch of Advanced queries in March 2019, indirect relationships can easily be answered by running Structured Query Language (SQL) queries such as:
+
+SELECT
+ resourceId,
+ resourceType
+WHERE
+ resourceType ='AWS::EC2::Instance'
+AND
+ relationships.resourceId = 'sg-234213'
+
+By deprecating indirect relationships, we can optimize the information contained within a Configuration Item while reducing AWS Config costs related to relationship changes. This is especially useful in case of ephemeral workloads where there is a high volume of configuration changes for EC2 resource types.
+
+Which resource relationships are being removed?
+
+Resource Type: Related Resource Type
+1 AWS::EC2::CustomerGateway: AWS::VPN::Connection
+2 AWS::EC2::Instance: AWS::EC2::EIP, AWS::EC2::RouteTable
+3 AWS::EC2::NetworkInterface: AWS::EC2::EIP, AWS::EC2::RouteTable
+4 AWS::EC2::SecurityGroup: AWS::EC2::Instance, AWS::EC2::NetworkInterface
+5 AWS::EC2::Subnet: AWS::EC2::Instance, AWS::EC2::NetworkACL, AWS::EC2::NetworkInterface, AWS::EC2::RouteTable
+6 AWS::EC2::VPC: AWS::EC2::Instance, AWS::EC2::InternetGateway, AWS::EC2::NetworkACL, AWS::EC2::NetworkInterface, AWS::EC2::RouteTable, AWS::EC2::Subnet, AWS::EC2::VPNGateway, AWS::EC2::SecurityGroup
+7 AWS::EC2::VPNGateway: AWS::EC2::RouteTable, AWS::EC2::VPNConnection
+
+Alternate mechanism to retrieve this relationship information:
+The SelectResourceConfig API accepts a SQL SELECT command, performs the corresponding search, and returns resource configurations matching the properties. You can use this API to retrieve the same relationship information. For example, to retrieve the list of all EC2 Instances related to a particular VPC vpc-1234abc, you can use the following query:
+
+SELECT
+ resourceId,
+ resourceType
+WHERE
+ resourceType ='AWS::EC2::Instance'
+AND
+ relationships.resourceId = 'vpc-1234abc'
+
+If you have any questions regarding this deprecation plan, please contact AWS Support [1]. Additional sample queries to retrieve the relationship information for the resources listed above is provided in [2].
+
+[1] https://aws.amazon.com/support
+[2] https://docs.aws.amazon.com/config/latest/developerguide/examplerelationshipqueries.html), EventMetadata={})
+[main] INFO aws.health.high.availability.endpoint.demo.HighAvailabilityV2Workflow - EventDetails(Event=Event(Arn=arn:aws:health:us-west-2::event/STORAGEGATEWAY/AWS_STORAGEGATEWAY_OPERATIONAL_ISSUE/AWS_STORAGEGATEWAY_OPERATIONAL_ISSUE_WQPFF_7809546408, Service=STORAGEGATEWAY, EventTypeCode=AWS_STORAGEGATEWAY_OPERATIONAL_ISSUE, EventTypeCategory=issue, Region=us-west-2, StartTime=2020-09-13T19:46:48.335Z, LastUpdatedTime=2020-09-14T01:30:16.216Z, StatusCode=open, EventScopeCode=PUBLIC), EventDescription=EventDescription(LatestDescription=Storage Gateway VMs Offline
+
+[12:46 PM PDT] Beginning at 7:39 AM PDT, we are experiencing an issue where Storage Gateway VMs appear to be offline and are not able to perform out of cache reads or upload to our service. The gateways will continue to accept writes but will not be able to proceed to upload them to our service until this issue is resolved. We have identified the root cause and are working towards resolution.
+
+[02:59 PM PDT] We continue to work towards resolution on the issue impacting Storage Gateway. The Gateways will continue to accept writes but will not be able to proceed to upload them to our service until this issue is resolved. Based upon the information available at this time, full resolution is estimated to take 2 hours. We are working through the recovery process now and will continue to keep you updated if this timeline changes.
+
+[05:29 PM PDT] We are beginning to see recovery in some AWS Regions for the issue impacting Storage Gateway. We continue to work towards resolution for all impacted Regions. We will update the message for each AWS Region as recovery occurs.
+
+[06:30 PM PDT] Beginning at 7:39 AM PDT we experienced an issue impacting Storage Gateway in the US-WEST-2 Region. During the event Gateways were unable to perform out of cache reads and appeared offline in the SGW console. Gateways continued to accept writes but were unable to upload them to the AWS service. The issue has been resolved and the service is operating normally. ), EventMetadata={})
+```
+
+## References
+
+* AWS Java SDK V2 health client [javadoc](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/health/HealthClient.html) and [source code](https://repo1.maven.org/maven2/software/amazon/awssdk/health/2.14.2/)
+* The library used in this demo for DNS lookups - [dnsjava](https://github.com/dnsjava/dnsjava)
+
+## License
+
+AWS Health Tools are licensed under the Apache 2.0 License

--- a/high-availability-endpoint/java/build.gradle
+++ b/high-availability-endpoint/java/build.gradle
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+plugins {
+    // Apply the java plugin to add support for Java
+    id 'java'
+
+    // Apply the application plugin to add support for building a CLI application.
+    id 'application'
+}
+
+repositories {
+    // Use jcenter for resolving dependencies.
+    // You can declare any Maven/Ivy/file repository here.
+    jcenter()
+}
+
+dependencies {
+    // This dependency is used by the application.
+    implementation 'software.amazon.awssdk:health:2.+'
+    implementation 'dnsjava:dnsjava:3.1.0'
+    implementation 'org.slf4j:slf4j-simple:1.7.30'
+
+    // Use JUnit Jupiter API for testing.
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
+
+    // Use JUnit Jupiter Engine for testing.
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.0'
+}
+
+application {
+    // Define the main class for the application.
+    mainClassName = 'aws.health.high.availability.endpoint.demo.App'
+}
+
+test {
+    // Use junit platform for unit tests
+    useJUnitPlatform()
+}

--- a/high-availability-endpoint/java/settings.gradle
+++ b/high-availability-endpoint/java/settings.gradle
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+rootProject.name = 'aws-health-high-availability-endpoint-demo-java'

--- a/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/ActiveRegionHasChangedException.java
+++ b/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/ActiveRegionHasChangedException.java
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package aws.health.high.availability.endpoint.demo;
+
+public final class ActiveRegionHasChangedException extends Exception {
+    public ActiveRegionHasChangedException(String message) {
+        super(message);
+    }
+
+    public ActiveRegionHasChangedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/App.java
+++ b/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/App.java
@@ -1,0 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package aws.health.high.availability.endpoint.demo;
+
+/**
+ * Sample workflow for using the AWS Health API high availability endpoint
+ */
+public class App {
+    public static void main(String[] args) throws RegionLookupException {
+
+        // Example using the HealthClient from the AWS Java SDK V2
+        HighAvailabilityV2Workflow v2Workflow = new HighAvailabilityV2Workflow();
+        v2Workflow.doWorkflow();
+    }
+}

--- a/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/HighAvailabilityV2HealthClient.java
+++ b/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/HighAvailabilityV2HealthClient.java
@@ -1,0 +1,64 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package aws.health.high.availability.endpoint.demo;
+
+import software.amazon.awssdk.services.health.HealthClient;
+import software.amazon.awssdk.services.health.HealthClientBuilder;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is an example of using the Health API endpoint DNS lookup strategy
+ * with the AWS Java SDK V2 Health client.
+ */
+public final class HighAvailabilityV2HealthClient {
+    private static String activeRegion;
+
+    private static HealthClient healthClient;
+
+    private HighAvailabilityV2HealthClient() {}
+
+    public static synchronized HealthClient getHealthClient() throws RegionLookupException, ActiveRegionHasChangedException {
+        String currentActiveRegion = RegionLookup.getCurrentActiveRegion();
+        if (activeRegion == null) {
+            // This is the first time we've done the DNS lookup
+            activeRegion = currentActiveRegion;
+        } else {
+            // If the active region has changed since the last time we did the
+            // DNS lookup we throw an exception to let the calling code know
+            // abount the change
+            if (!currentActiveRegion.equals(activeRegion)) {
+                String oldActiveRegion = activeRegion;
+                activeRegion = currentActiveRegion;
+
+                if (healthClient != null) {
+                    // Close the existing client so that the next call to this
+                    // method will create a new client using the new active
+                    // region
+                    healthClient.close();
+                    healthClient = null;
+                }
+
+                throw new ActiveRegionHasChangedException("Active region has changed from [" + oldActiveRegion + "] to [" + currentActiveRegion + "]");
+            }
+        }
+
+        if (healthClient == null) {
+            // Create the Health client using the region extraced from the global
+            // endpoint CNAME
+            healthClient = HealthClient.builder()
+                .region(Region.of(activeRegion))
+                .credentialsProvider(
+                    // See https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/setup-credentials.html
+                    DefaultCredentialsProvider.builder().build()
+                )
+                .build();
+        }
+
+        return healthClient;
+    } 
+
+}

--- a/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/HighAvailabilityV2Workflow.java
+++ b/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/HighAvailabilityV2Workflow.java
@@ -1,0 +1,107 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package aws.health.high.availability.endpoint.demo;
+
+import software.amazon.awssdk.services.health.HealthClient;
+import software.amazon.awssdk.services.health.model.DateTimeRange;
+import software.amazon.awssdk.services.health.model.DescribeEventDetailsRequest;
+import software.amazon.awssdk.services.health.model.DescribeEventDetailsResponse;
+import software.amazon.awssdk.services.health.model.DescribeEventsRequest;
+import software.amazon.awssdk.services.health.model.DescribeEventsResponse;
+import software.amazon.awssdk.services.health.model.Event;
+import software.amazon.awssdk.services.health.model.EventFilter;
+import software.amazon.awssdk.services.health.model.EventStatusCode;
+import software.amazon.awssdk.services.health.paginators.DescribeEventsIterable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Example workflow when using the AWS Health API high availability endpoint
+ * and the AWS Java V2 SDK.
+ */
+public class HighAvailabilityV2Workflow {
+    private static final Logger log = LoggerFactory.getLogger(HighAvailabilityV2Workflow.class);
+
+    /**
+     * Helper method to provide a shorter way of referring to the singleton
+     * client method
+     */
+    private HealthClient getV2Client() throws RegionLookupException, ActiveRegionHasChangedException {
+        return HighAvailabilityV2HealthClient.getHealthClient();
+    }
+
+    /**
+     * Log the details of an event
+     */
+    private void eventDetails(Event event) throws RegionLookupException, ActiveRegionHasChangedException {
+        // NOTE: It is more efficient to call describeEventDetails with a batch
+        // of eventArns, but for simplicitly of this demo we call it with a
+        // single eventArn
+        DescribeEventDetailsRequest detailsRequest = DescribeEventDetailsRequest.builder()
+            .eventArns(Collections.singleton(event.arn()))
+            .build();
+
+        DescribeEventDetailsResponse detailsResponse = getV2Client().describeEventDetails(detailsRequest);
+        detailsResponse.successfulSet().stream().forEach(detail -> log.info(detail.toString()));
+    }
+
+    private void describeEvents() throws RegionLookupException, ActiveRegionHasChangedException {
+        // Describe events using the same default filters as the Personal Health Dashboard (PHD). i.e
+        //
+        // Return all open or upcoming events which started in the last 7 days, ordered by event lastUpdatedTime
+
+        List<EventStatusCode> eventStatusCodes = new ArrayList<>();
+        eventStatusCodes.add(EventStatusCode.OPEN);
+        eventStatusCodes.add(EventStatusCode.UPCOMING);
+
+        DateTimeRange sevenDaysAgo = DateTimeRange.builder().from(Instant.now().minus(Duration.ofDays(7))).build();
+
+        DescribeEventsRequest describeEventsRequest = DescribeEventsRequest.builder()
+            .filter(EventFilter.builder().eventStatusCodes(eventStatusCodes).startTimes(Collections.singleton(sevenDaysAgo)).build())
+            .build();
+
+        int numberOfMatchingEvents = 0;
+        DescribeEventsIterable describeEventsResponses = getV2Client().describeEventsPaginator(describeEventsRequest);
+        for (DescribeEventsResponse eventsResponse : describeEventsResponses) {
+            for (Event event: eventsResponse.events()) {
+                eventDetails(event);
+                numberOfMatchingEvents++;
+            }
+        }
+
+        if (numberOfMatchingEvents == 0) {
+            log.info("There are no AWS Health events that match the given filters");
+        }
+    }
+
+    public void doWorkflow() throws RegionLookupException {
+        // An example workflow using the AWS Health API's high availability
+        // endpoint and the AWS Java SDK V2
+
+        // If the active endpoint changes we recommend you restart any
+        // workflows.
+        //
+        // In this sample code we throw an exception if the active
+        // endpoint changes in the middle of a workflow and restart the
+        // workflow using the new active endpoint.
+        boolean restartWorkflow = true;
+
+        while (restartWorkflow) {
+            try {
+                // Describe events for the account
+                describeEvents();
+                restartWorkflow = false;
+            } catch (ActiveRegionHasChangedException ex) {
+                log.info("The AWS Health API active region has changed. Restarting the workflow using the new active region!" + ex);
+            }
+        }
+    }
+}

--- a/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/RegionLookup.java
+++ b/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/RegionLookup.java
@@ -1,0 +1,39 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package aws.health.high.availability.endpoint.demo;
+
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.CNAMERecord;
+import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.Type;
+import org.xbill.DNS.Record;
+
+public final class RegionLookup {
+    public static final String GLOBAL_HEALTH_ENDPOINT = "global.health.amazonaws.com"; 
+
+    public static String getCurrentActiveRegion() throws RegionLookupException {
+        // Init lookup object
+        Lookup dnsLookup = null;
+        try {
+            dnsLookup = new Lookup(GLOBAL_HEALTH_ENDPOINT, Type.CNAME);
+        } catch (TextParseException e) {
+            throw new RegionLookupException("Failed to parse DNS name [" + GLOBAL_HEALTH_ENDPOINT + "]", e);
+        } 
+        dnsLookup.setCache(null); // Never use caching, always do a full a DNS lookup
+
+        // Do the DNS lookup
+        Record[] records = dnsLookup.run();
+        if (records == null || records.length == 0) {
+            throw new RegionLookupException("Failed to resolve the DNS name [" + GLOBAL_HEALTH_ENDPOINT + "]");
+        }
+        CNAMERecord cnameRecord = (CNAMERecord)records[0];
+        String regionalDNSName = cnameRecord.getTarget().toString(true);
+
+        // The CNAME will look something like: "health.us-east-1.amazonaws.com"
+        // Extract the region name (e.g. us-east-1) to use for SigV4 signing
+        String[] cnameParts = regionalDNSName.split("\\.");
+        String regionName = cnameParts[1].toLowerCase(); // The region is always the second item in the array
+
+        return regionName;
+    }
+}

--- a/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/RegionLookupException.java
+++ b/high-availability-endpoint/java/src/main/java/aws/health/high/availability/endpoint/demo/RegionLookupException.java
@@ -1,0 +1,13 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+package aws.health.high.availability.endpoint.demo;
+
+public final class RegionLookupException extends Exception {
+    public RegionLookupException(String message) {
+        super(message);
+    }
+
+    public RegionLookupException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/high-availability-endpoint/python/README.md
+++ b/high-availability-endpoint/python/README.md
@@ -1,0 +1,80 @@
+## Using the high availability endpoint python demo
+
+To build and run this demo:
+
+1. Download / clone the repo [AWS Health high availability endpoint demo](https://github.com/aws/aws-health-tools/high-availability-endpoint) from GitHub
+
+2. Install python 3
+
+See the [Python 3 Installation & Setup Guide](https://realpython.com/installing-python/) for steps on installing Python for Linux, macOS and Windows
+
+3. Navigate to the python demo project directory in a command line window:
+
+```
+cd python
+```
+
+4. Create a virtual environment by running the following commands:
+
+```
+pip3 install virtualenv 
+virtualenv -p python3 v-aws-health-env
+```
+
+NOTE: For Python 3.3 and newer you can use the built-in [venv module](https://docs.python.org/3/library/venv.html) to create a virtual environment, instead of installing virtualenv.
+
+```
+python3 -m venv v-aws-health-env
+```
+
+5. Activate the virtual environment by running the command:
+
+```
+source v-aws-health-env/bin/activate
+```
+
+6. Install dependencies by running the command:
+
+```
+pip install -r requirements.txt
+```
+
+7. Set the AWS credentials:
+
+[Configure AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html). e.g. using profiles or environment variables
+
+```
+export AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE"
+export AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+export AWS_SESSION_TOKEN="your-aws-token"
+```
+
+8. Enter the following command to run the demo:
+
+```
+python3 main.py
+```
+
+The output will look something like:
+
+```
+INFO:botocore.credentials:Found credentials in environment variables.
+INFO:root:Details: {'arn': 'arn:aws:health:global::event/SECURITY/AWS_SECURITY_NOTIFICATION/AWS_SECURITY_NOTIFICATION_0e35e47e-2247-47c4-a9a5-876544042721', 'service': 'SECURITY', 'eventTypeCode': 'AWS_SECURITY_NOTIFICATION', 'eventTypeCategory': 'accountNotification', 'region': 'global', 'startTime': datetime.datetime(2020, 8, 19, 23, 30, 42, 476000, tzinfo=tzlocal()), 'lastUpdatedTime': datetime.datetime(2020, 8, 20, 20, 44, 9, 547000, tzinfo=tzlocal()), 'statusCode': 'open', 'eventScopeCode': 'PUBLIC'}, description: {'latestDescription': 'This is the second notice regarding TLS requirements on FIPS endpoints.\n\nWe are in the process of updating all AWS Federal Information Processing Standard (FIPS) endpoints across all AWS regions to Transport Layer Security (TLS) version 1.2 by March 31, 2021 . In order to avoid an interruption in service, we encourage you to act now, by ensuring that you connect to AWS FIPS endpoints at a TLS version of 1.2. If your client applications fail to support TLS 1.2 it will result in connection failures when TLS versions below 1.2 are no longer supported.\n\nBetween now and March 31, 2021 AWS will remove TLS 1.0 and TLS 1.1 support from each FIPS endpoint where no connections below TLS 1.2 are detected over a 30-day period. After March 31, 2021 we may deploy this change to all AWS FIPS endpoints, even if there continue to be customer connections detected at TLS versions below 1.2. \n\nWe will provide additional updates and reminders on the AWS Security Blog, with a ‘TLS’ tag [1]. If you need further guidance or assistance, please contact AWS Support [2] or your Technical Account Manager (TAM). Additional information is below.\n\nHow can I identify clients that are connecting with TLS 1.0/1.1?\nFor customers using S3 [3], Cloudfront [4] or Application Load Balancer [5] you can use your access logs to view the TLS connection information for these services, and identify client connections that are not at TLS 1.2. If you are using the AWS Developer Tools on your clients, you can find information on how to properly configure your client’s TLS versions by visiting Tools to Build on AWS [7] or our associated AWS Security Blog has a link for each unique code language [7].\n\nWhat is Transport Layer Security (TLS)?\nTransport Layer Security (TLS Protocols) are cryptographic protocols designed to provide secure communication across a computer network [6].\n\nWhat are AWS FIPS endpoints? \nAll AWS services offer Transport Layer Security (TLS) 1.2 encrypted endpoints that can be used for all API calls. Some AWS services also offer FIPS 140-2 endpoints [9] for customers that require use of FIPS validated cryptographic libraries. \n\n[1] https://aws.amazon.com/blogs/security/tag/tls/\n[2] https://aws.amazon.com/support\n[3] https://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html\n[4] https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html\n[5] https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html\n[6] https://aws.amazon.com/tools\n[7] https://aws.amazon.com/blogs/security/tls-1-2-to-become-the-minimum-for-all-aws-fips-endpoints\n[8] https://en.wikipedia.org/wiki/Transport_Layer_Security\n[9] https://aws.amazon.com/compliance/fips'}
+```
+
+9. Deactive the virtual environment
+
+Lastly, when you have finished with everything you can deactivate the environment by running the following command:
+
+```
+deactivate
+```
+
+## References
+
+* [Boto3 Python SDK AWS Health doco](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/health.html#Health.Client)
+* The library used in this demo for DNS lookups - dnspython [doco](https://dnspython.readthedocs.io/en/stable/) and [source code](https://github.com/rthalley/dnspython/)
+
+## License
+
+AWS Health Tools are licensed under the Apache 2.0 License

--- a/high-availability-endpoint/python/health_client.py
+++ b/high-availability-endpoint/python/health_client.py
@@ -1,0 +1,32 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from region_lookup import active_region
+import boto3
+
+class ActiveRegionHasChangedError(Exception):
+    """Rasied when the active region has changed"""
+    pass
+
+class HealthClient:
+    __active_region = None
+    __client = None
+
+    @staticmethod
+    def client():
+        if not HealthClient.__active_region:
+            HealthClient.__active_region = active_region()
+        else:
+            current_active_region = active_region()
+            if current_active_region != HealthClient.__active_region:
+                old_active_region = HealthClient.__active_region
+                HealthClient.__active_region = current_active_region
+
+                if HealthClient.__client:
+                    HealthClient.__client = None
+
+                raise ActiveRegionHasChangedError('Active region has changed from [' + old_active_region + '] to [' + current_active_region + ']')
+
+        if not HealthClient.__client:
+            HealthClient.__client = boto3.client('health', region_name=HealthClient.__active_region)
+
+        return HealthClient.__client

--- a/high-availability-endpoint/python/main.py
+++ b/high-availability-endpoint/python/main.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+from  health_client import HealthClient, ActiveRegionHasChangedError
+import datetime
+import logging
+logging.basicConfig(level=logging.INFO)
+
+def event_details(event):
+    # NOTE: It is more efficient to call describe_event_details with a batch
+    # of eventArns, but for simplicitly of this demo we call it with a
+    # single eventArn
+    event_details_response = HealthClient.client().describe_event_details(eventArns=[event['arn']])
+    for event_details in event_details_response['successfulSet']:
+        logging.info('Details: %s, description: %s', event_details['event'], event_details['eventDescription'])
+
+def describe_events():
+    events_paginator = HealthClient.client().get_paginator('describe_events')
+
+    # Describe events using the same default filters as the Personal Health
+    # Dashboard (PHD). i.e
+    #
+    # Return all open or upcoming events which started in the last 7 days,
+    # ordered by event lastUpdatedTime
+
+    events_pages = events_paginator.paginate(filter={
+        'startTimes': [
+            {
+                'from': datetime.datetime.now() - datetime.timedelta(days=7)
+            }
+        ],
+        'eventStatusCodes': ['open', 'upcoming']
+    })
+
+    number_of_matching_events = 0
+    for events_page in events_pages:
+        for event in events_page['events']:
+            number_of_matching_events += 1
+            event_details(event)
+
+    if number_of_matching_events == 0:
+        logging.info('There are no AWS Health events that match the given filters')
+
+
+# If the active endpoint changes we recommend you restart any workflows.
+#
+# In this sample code we throw an exception if the active endpoint changes in
+# the middle of a workflow and restart the workflow using the new active
+# endpoint.
+restart_workflow = True
+
+while restart_workflow:
+    try:
+        describe_events()
+        restart_workflow = False
+    except ActiveRegionHasChangedError as are:
+        logging.info("The AWS Health API active region has changed. Restarting the workflow using the new active region!, %s", are)

--- a/high-availability-endpoint/python/region_lookup.py
+++ b/high-availability-endpoint/python/region_lookup.py
@@ -1,0 +1,19 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+import dns.resolver
+
+class RegionLookupError(Exception):
+    """Rasied when there was a problem when looking up the active region"""
+    pass
+
+def active_region():
+    qname = 'global.health.amazonaws.com'
+    try:
+        answers = dns.resolver.resolve(qname, 'CNAME')
+    except Exception as e:
+        raise RegionLookupError('Failed to resolve {}'.format(qname), e)
+    if len(answers) != 1:
+        raise RegionLookupError('Failed to get a single answer when resolving {}'.format(qname))
+    name = str(answers[0].target) # e.g. health.us-east-1.amazonaws.com.
+    region_name = name.split('.')[1] # Region name is the 1st in split('.') -> ['health', 'us-east-1', 'amazonaws', 'com', '']
+    return region_name

--- a/high-availability-endpoint/python/requirements.txt
+++ b/high-availability-endpoint/python/requirements.txt
@@ -1,0 +1,4 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+boto3 > 1.15
+dnspython >= 2.0.0


### PR DESCRIPTION
*Description of changes:*

Demo code for using the AWS Health API high availability endpoint, so that customers can determine and use the current active endpoint, and therefore always get the latest health events for their accounts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
