### PR TITLE
Update sns-topic-publisher.yml

### DIFF
--- a/sns-topic-publisher/cfn-templates/sns-topic-publisher.yml
+++ b/sns-topic-publisher/cfn-templates/sns-topic-publisher.yml
@@ -102,7 +102,7 @@ Resources:
                     }
                 });
             };
-      Runtime: "nodejs10.x"
+      Runtime: "nodejs14.x"
       Timeout: "25"
   LambdaInvokePermission: 
     Type: "AWS::Lambda::Permission"


### PR DESCRIPTION
nodejs10.x is no more supported on Lambda

*Issue #, if available:*

Description of changes: Changing run time version. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
