### PR TITLE
add coralogix notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Setup and usage instructions are present for each tool in its respective directo
 [AWS Health event Amazon Simple Notification Service (SNS) Topic Publisher](sns-topic-publisher/) <br />
 [AWS Health event Slack notifier](slack-notifier/) <br />
 [AWS Health event Direct Connect maintenance notifier](dx-maintenance-notifier/) <br />
+[AWS Health event Coralogix notifier](coralogix-notifier/) <br />
 [AWS Health Abuse event DOS report notifier](dos-report-notifier/) <br />
 [AWS Health SHD event Chime/Slack/SNS notifier](shd-notifier/) <br />
 [AWS Health Organizational View Alerts](https://github.com/aws-samples/aws-health-organizational-view-alerts) <br />

--- a/coralogix-notifier/IAMPolicy
+++ b/coralogix-notifier/IAMPolicy
@@ -1,0 +1,14 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/coralogix-notifier/LambdaFunction.py
+++ b/coralogix-notifier/LambdaFunction.py
@@ -1,0 +1,44 @@
+import os
+import time
+import logging
+import json
+import urllib.error
+from urllib.request import Request, urlopen
+
+CORALOGIX_LOG_URL = os.getenv('CORALOGIX_LOG_URL')
+PRIVATE_KEY = os.getenv('PRIVATE_KEY')
+APP_NAME = os.getenv('APP_NAME')
+SUB_SYSTEM = os.getenv('SUB_SYSTEM')
+
+WARN = 4
+TIMEOUT = os.getenv('CORALOGIX_TIMEOUT_HTTP', 30)
+RETRIES = os.getenv('CORALOGIX_RETRIES_HTTP', 2)
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+def lambda_handler(event, context):
+    message = {
+        "privateKey": str(PRIVATE_KEY),
+        "applicationName": str(APP_NAME),
+        "subsystemName": str(SUB_SYSTEM),
+        "logEntries": [{"timestamp": (time.time() * 1000), "severity": WARN, "text": event}]
+    }
+    jsondata = json.dumps(message).encode('utf-8')
+    for attempt in range(int(RETRIES)):
+        try:
+            req = Request(CORALOGIX_LOG_URL)
+            req.add_header('Content-Type', 'application/json; charset=utf-8')
+            req.add_header('Content-Length', len(jsondata))
+            response = urlopen(req, data=jsondata,timeout=TIMEOUT)
+            if response.getcode() == 200:
+                logger.info("Health log published to Coralogix successfully 200 OK")
+                return True
+            else:
+                logger.error("health log publish failed, status code %d, %b", response.getcode(), response.read)
+        except urllib.error.URLError as e:
+            logger.error("URL Error %s", e)
+        except urllib.error.HTTPError as e:
+            logger.error("HTTP Error %s", e)
+        logger.info("attempt number %d", attempt + 1)
+        time.sleep(5)

--- a/coralogix-notifier/README.md
+++ b/coralogix-notifier/README.md
@@ -8,7 +8,6 @@ This tool can be used to send logs to Coralogix endpoints when an AWS Health eve
 
 Choose **Launch Stack** to launch the template in the US East (N. Virginia) Region in your account:
 
-!!!! update this url !!!!
 [![Launch AWS Health Coralogix Notifier](../images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=CoralogixNotifier&templateURL=https://aws-health-tools-assets.s3.amazonaws.com/cloudformation-templates/coralogix-notifier.json)
 
 The CloudFormation template requires the following parameters:

--- a/coralogix-notifier/README.md
+++ b/coralogix-notifier/README.md
@@ -1,0 +1,28 @@
+## AWS Health Coralogix Notifier
+
+### Description
+
+This tool can be used to send logs to Coralogix endpoints when an AWS Health event happens by using AWS Lambda and Amazon CloudWatch Events.
+
+### Setup and Usage
+
+Choose **Launch Stack** to launch the template in the US East (N. Virginia) Region in your account:
+
+!!!! update this url !!!!
+[![Launch AWS Health SMS Notifier](../images/cloudformation-launch-stack.png)](https://google.com)
+
+The CloudFormation template requires the following parameters:
+
+- AWS Health Tool configuration
+  - **CORALOGIX_LOG_URL**: The Coralogix logs ingress endpoint.
+  - **PRIVATE_KEY**: Your Coralogix private key (sensitive).
+  - **APP_NAME**: In Coralogix logs should be tagged by application name and sub system name.
+  - **SUB_SYSTEM**: In Coralogix logs should be tagged by application name and sub system name.
+
+
+More information about AWS Health is available here: http://docs.aws.amazon.com/health/latest/ug/what-is-aws-health.html
+
+Note that this is a just an example of how to set up automation with AWS Health, Amazon CloudWatch Events, and AWS Lambda. We recommend testing this example and tailoring it to your environment before using it in your production environment.
+
+### License
+AWS Health Tools are licensed under the Apache 2.0 License.

--- a/coralogix-notifier/README.md
+++ b/coralogix-notifier/README.md
@@ -9,7 +9,7 @@ This tool can be used to send logs to Coralogix endpoints when an AWS Health eve
 Choose **Launch Stack** to launch the template in the US East (N. Virginia) Region in your account:
 
 !!!! update this url !!!!
-[![Launch AWS Health SMS Notifier](../images/cloudformation-launch-stack.png)](https://google.com)
+[![Launch AWS Health Coralogix Notifier](../images/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/new?stackName=CoralogixNotifier&templateURL=https://aws-health-tools-assets.s3.amazonaws.com/cloudformation-templates/coralogix-notifier.json)
 
 The CloudFormation template requires the following parameters:
 

--- a/coralogix-notifier/cfn-templates/coralogix-notifier.json
+++ b/coralogix-notifier/cfn-templates/coralogix-notifier.json
@@ -70,7 +70,7 @@
         "CoralogixNotifierLambda": {
             "Type": "AWS::Lambda::Function",
             "Properties": {
-                "Handler": "LambdaFunction.lambda_handler",
+                "Handler": "index.lambda_handler",
                 "Role": {
                     "Fn::GetAtt": [
                         "CxNotifierLambdaRole",

--- a/coralogix-notifier/cfn-templates/coralogix-notifier.json
+++ b/coralogix-notifier/cfn-templates/coralogix-notifier.json
@@ -1,0 +1,154 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Parameters": {
+        "CoralogixLogURL": {
+            "Type": "String",
+            "Description": "Please enter the Coralogix log URL endpoint:"
+        },
+        "PrivateKey": {
+            "Type": "String",
+            "Description": "A private key which is used to validate your authenticity\nPlease enter your private key:"
+        },
+        "AppName": {
+            "Type": "String",
+            "Description": "The name of your main application\nPlease enter your app name:"
+        },
+        "SubSystem": {
+            "Type": "String",
+            "Description": "Your application probably has multiple subsystems\nPlease enter your sub system name:"
+        }
+    },
+    "Resources": {
+        "CxNotifierLambdaRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/"
+            }
+        },
+        "CxLambdaRolePolicies": {
+            "Type": "AWS::IAM::Policy",
+            "Properties": {
+                "PolicyName": "LambdaPolicy",
+                "PolicyDocument": {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Sid": "Stmt12349896368829",
+                            "Action": [
+                                "logs:CreateLogGroup",
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents"
+                            ],
+                            "Effect": "Allow",
+                            "Resource": "arn:aws:logs:*:*:*"
+                        }
+                    ]
+                },
+                "Roles": [
+                    {
+                        "Ref": "CxNotifierLambdaRole"
+                    }
+                ]
+            }
+        },
+        "CoralogixNotifierLambda": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "Handler": "LambdaFunction.lambda_handler",
+                "Role": {
+                    "Fn::GetAtt": [
+                        "CxNotifierLambdaRole",
+                        "Arn"
+                    ]
+                },
+                "Code": {
+                    "ZipFile": {
+                        "Fn::Sub": "# Sample Lambda Function to post notifications to a slack channel when an AWS Health event happens\nimport os\nimport time\nimport logging\nimport json\nimport urllib.error\nfrom urllib.request import Request, urlopen\n\nCORALOGIX_LOG_URL = os.getenv('CORALOGIX_LOG_URL')\nPRIVATE_KEY = os.getenv('PRIVATE_KEY')\nAPP_NAME = os.getenv('APP_NAME')\nSUB_SYSTEM = os.getenv('SUB_SYSTEM')\n\nWARN = 4\nTIMEOUT = os.getenv('CORALOGIX_TIMEOUT_HTTP', 30)\nRETRIES = os.getenv('CORALOGIX_RETRIES_HTTP', 2)\n\nlogger = logging.getLogger()\nlogger.setLevel(logging.INFO)\n\ndef lambda_handler(event, context):\n    message = {\n        \"privateKey\": str(PRIVATE_KEY),\n        \"applicationName\": str(APP_NAME),\n        \"subsystemName\": str(SUB_SYSTEM),\n        \"logEntries\": [{\"timestamp\": (time.time() * 1000), \"severity\": WARN, \"text\": event}]\n    }\n    jsondata = json.dumps(message).encode('utf-8')\n    for attempt in range(int(RETRIES)):\n        try:\n            req = Request(CORALOGIX_LOG_URL)\n            req.add_header('Content-Type', 'application/json; charset=utf-8')\n            req.add_header('Content-Length', len(jsondata))\n            response = urlopen(req, data=jsondata,timeout=TIMEOUT)\n            if response.getcode() == 200:\n                logger.info(\"Health log published to Coralogix successfully 200 OK\")\n                return True\n            else:\n                logger.error(\"health log publish failed, status code %d, %b\", response.getcode(), response.read)\n        except urllib.error.URLError as e:\n            logger.error(\"URL Error %s\", e)\n        except urllib.error.HTTPError as e:\n            logger.error(\"HTTP Error %s\", e)\n        logger.info(\"attempt number %d\", attempt + 1)\n        time.sleep(5)\n"
+                    }
+                },
+                "Environment": {
+                    "Variables": {
+                        "CORALOGIX_LOG_URL": {
+                            "Ref": "CoralogixLogURL"
+                        },
+                        "PRIVATE_KEY": {
+                            "Ref": "PrivateKey"
+                        },
+                        "APP_NAME": {
+                            "Ref": "AppName"
+                        },
+                        "SUB_SYSTEM": {
+                            "Ref": "SubSystem"
+                        }
+                    }
+                },
+                "Tags": [
+                    {
+                        "Key": "coralogix.com/monitor",
+                        "Value": "true"
+                    }
+                ],
+                "Runtime": "python3.8",
+                "Timeout": "60"
+            }
+        },
+        "CxLambdaInvokePermission": {
+            "Type": "AWS::Lambda::Permission",
+            "Properties": {
+                "FunctionName": {
+                    "Fn::GetAtt": [
+                        "CoralogixNotifierLambda",
+                        "Arn"
+                    ]
+                },
+                "Action": "lambda:InvokeFunction",
+                "Principal": "events.amazonaws.com",
+                "SourceArn": {
+                    "Fn::GetAtt": [
+                        "CloudWatchRuleHealth",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "CloudWatchRuleHealth": {
+            "Type": "AWS::Events::Rule",
+            "Properties": {
+                "Description": "EventRule for Coralogix",
+                "EventPattern": {
+                    "source": [
+                        "aws.health"
+                    ]
+                },
+                "State": "ENABLED",
+                "Targets": [
+                    {
+                        "Arn": {
+                            "Fn::GetAtt": [
+                                "CoralogixNotifierLambda",
+                                "Arn"
+                            ]
+                        },
+                        "Id": "CoralogixNotifierLambda"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/coralogix-notifier/cfn-templates/coralogix-notifier.yml
+++ b/coralogix-notifier/cfn-templates/coralogix-notifier.yml
@@ -51,7 +51,7 @@ Resources:
   CoralogixNotifierLambda:
     Type: 'AWS::Lambda::Function'
     Properties:
-      Handler: LambdaFunction.lambda_handler
+      Handler: index.lambda_handler
       Role: !GetAtt 
         - CxNotifierLambdaRole
         - Arn

--- a/coralogix-notifier/cfn-templates/coralogix-notifier.yml
+++ b/coralogix-notifier/cfn-templates/coralogix-notifier.yml
@@ -1,0 +1,140 @@
+AWSTemplateFormatVersion: 2010-09-09
+Parameters:
+  CoralogixLogURL:
+    Type: String
+    Description: 'Please enter the Coralogix log URL endpoint:'
+  PrivateKey:
+    Type: String
+    Description: |-
+      A private key which is used to validate your authenticity
+      Please enter your private key:
+  AppName:
+    Type: String
+    Description: |-
+      The name of your main application
+      Please enter your app name:
+  SubSystem:
+    Type: String
+    Description: |-
+      Your application probably has multiple subsystems
+      Please enter your sub system name:
+Resources:
+  CxNotifierLambdaRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Path: /
+  CxLambdaRolePolicies:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyName: LambdaPolicy
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: Stmt12349896368829
+            Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Effect: Allow
+            Resource: 'arn:aws:logs:*:*:*'
+      Roles:
+        - !Ref CxNotifierLambdaRole
+  CoralogixNotifierLambda:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Handler: LambdaFunction.lambda_handler
+      Role: !GetAtt 
+        - CxNotifierLambdaRole
+        - Arn
+      Code:
+        ZipFile:
+          Fn::Sub: |
+            # Sample Lambda Function to post notifications to a slack channel when an AWS Health event happens
+            import os
+            import time
+            import logging
+            import json
+            import urllib.error
+            from urllib.request import Request, urlopen
+
+            CORALOGIX_LOG_URL = os.getenv('CORALOGIX_LOG_URL')
+            PRIVATE_KEY = os.getenv('PRIVATE_KEY')
+            APP_NAME = os.getenv('APP_NAME')
+            SUB_SYSTEM = os.getenv('SUB_SYSTEM')
+
+            WARN = 4
+            TIMEOUT = os.getenv('CORALOGIX_TIMEOUT_HTTP', 30)
+            RETRIES = os.getenv('CORALOGIX_RETRIES_HTTP', 2)
+
+            logger = logging.getLogger()
+            logger.setLevel(logging.INFO)
+
+            def lambda_handler(event, context):
+                message = {
+                    "privateKey": str(PRIVATE_KEY),
+                    "applicationName": str(APP_NAME),
+                    "subsystemName": str(SUB_SYSTEM),
+                    "logEntries": [{"timestamp": (time.time() * 1000), "severity": WARN, "text": event}]
+                }
+                jsondata = json.dumps(message).encode('utf-8')
+                for attempt in range(int(RETRIES)):
+                    try:
+                        req = Request(CORALOGIX_LOG_URL)
+                        req.add_header('Content-Type', 'application/json; charset=utf-8')
+                        req.add_header('Content-Length', len(jsondata))
+                        response = urlopen(req, data=jsondata,timeout=TIMEOUT)
+                        if response.getcode() == 200:
+                            logger.info("Health log published to Coralogix successfully 200 OK")
+                            return True
+                        else:
+                            logger.error("health log publish failed, status code %d, %b", response.getcode(), response.read)
+                    except urllib.error.URLError as e:
+                        logger.error("URL Error %s", e)
+                    except urllib.error.HTTPError as e:
+                        logger.error("HTTP Error %s", e)
+                    logger.info("attempt number %d", attempt + 1)
+                    time.sleep(5)
+      Environment:
+        Variables:
+          CORALOGIX_LOG_URL: !Ref CoralogixLogURL
+          PRIVATE_KEY: !Ref PrivateKey
+          APP_NAME: !Ref AppName
+          SUB_SYSTEM: !Ref SubSystem
+      Tags:
+        - Key: coralogix.com/monitor
+          Value: 'true'
+      Runtime: python3.8
+      Timeout: '60'
+  CxLambdaInvokePermission:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      FunctionName: !GetAtt 
+        - CoralogixNotifierLambda
+        - Arn
+      Action: 'lambda:InvokeFunction'
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt 
+        - CloudWatchRuleHealth
+        - Arn
+  CloudWatchRuleHealth:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      Description: EventRule for Coralogix
+      EventPattern:
+        source:
+          - aws.health
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt 
+            - CoralogixNotifierLambda
+            - Arn
+          Id: CoralogixNotifierLambda


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In this PR I want to add a new notifier for Coralogix.

This tool can be used to send logs to Coralogix endpoints when an AWS Health event happens by using AWS Lambda and Amazon CloudWatch Events.
Today, over 10,000 DevOps and Security engineers around the world use Coralogix daily to monitor their stacks and fix production problems faster.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
