### PR TITLE
Adding custom wait seconds for state machine

### DIFF
--- a/shd-notifier/README.md
+++ b/shd-notifier/README.md
@@ -50,6 +50,11 @@ The CloudFormation template requires the following parameters:
   - 0 (Disable Debugging)
   - 1 (Enable debugging)
 
+- **WaitSeconds** - Control State Machine wait period of state transition. Allowed values:
+  - 60 (1 minutes - Allows Standard State machine to run for 2.5 days)
+  - 300 (5 minutes - Allows Standard State machine to run for 12.5 days)
+  - 600 (10 minutes - Allows Standard State machine to run for 25 days)
+
 #### Post-CloudFormation Installation Step
 Due to the CloudFormation limit on inline Lambda functions, after the CloudFormation stack has completed successfully, the **deploy.sh** script will need to be run to update the code for the Lambda functions. <br />
 Syntax: **deploy.sh** _\<CF_APPNAME\>_ _\<REGION\>_ <br/>

--- a/shd-notifier/shd-notifier.yml
+++ b/shd-notifier/shd-notifier.yml
@@ -48,6 +48,16 @@ Parameters:
     Description: Array of regions of interest used to filter events
     Type: String
     Default: "[]"
+  WaitSeconds:
+    Description: >
+      The rate (frequency) in seconds that determines State Machine waits before checking Event status again.
+      Longer wait allows State Machine to run for long duration
+    Type: Number
+    Default: 60
+    AllowedValues:
+      - 60
+      - 300
+      - 600
 Conditions:
   CreateSNSResources: !Equals [ !Ref ChatClient, sns ]
 Resources:
@@ -204,14 +214,14 @@ Resources:
       DefinitionString: !Sub
         - |-
           {
-            "Comment": "A state machine that monitors open AWS health issues and posts them every 15 minutes until they are closed. When closed it sends one last final closed post.",
+            "Comment": "A state machine that monitors open AWS health issues and posts them regularly until they are closed. When closed it sends one last final closed post.",
             "StartAt": "Post Event Status",
             "States": {
               "Post Event Status": {
                 "Type": "Task",
                 "Resource": "${postFunction}",
                 "ResultPath": "$.lastUpdatedTime",
-                "Next": "Wait 60 Seconds",
+                "Next": "Wait ${waitSeconds} Seconds",
                 "Retry": [
                   {
                     "ErrorEquals": ["States.ALL"],
@@ -221,9 +231,9 @@ Resources:
                   }
                 ]
               },
-              "Wait 60 Seconds": {
+              "Wait ${waitSeconds} Seconds": {
                 "Type": "Wait",
-                  "Seconds": 60,
+                  "Seconds": ${waitSeconds},
                   "Next": "Get Event Status"
               },
               "Get Event Status": {
@@ -274,7 +284,7 @@ Resources:
                     "Next": "Post Event Status"
                   }
                 ],
-                "Default": "Wait 60 Seconds"
+                "Default": "Wait ${waitSeconds} Seconds"
               },
               "Post Final Event Status": {
                 "Type": "Task",
@@ -292,6 +302,7 @@ Resources:
             }
           }
         - postFunction: !GetAtt PostFunction.Arn
+          waitSeconds: !Ref WaitSeconds
           eventStatusFunction: !GetAtt EventStatusFunction.Arn
           iteratorFunction: !GetAtt IteratorFunction.Arn
       RoleArn: !GetAtt StatesExecutionRole.Arn


### PR DESCRIPTION
*Issue #, if available:*
If consumers use code without PR https://github.com/aws/aws-health-tools/pull/69 (i.e. SHD checking all issues in health dashboard including account-specific), State Machine tends to fail for long-running issues. As Standard State Machine has a 25,000 execution events limit.

*Description of changes:*
By adding a larger wait period in State Machine (than default 60 secs), it is possible to run it for a longer duration and hence capture the Issue closure rather than fail with messages 'The execution reached the maximum number of history events (25000)'

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
