### PR TITLE
Added unicode decode to AWS health messages in slack-notifier

### DIFF
--- a/slack-notifier/LambdaFunction.py
+++ b/slack-notifier/LambdaFunction.py
@@ -37,10 +37,11 @@ logger.setLevel(logging.INFO)
 
 def lambda_handler(event, context):
     message =  str(event['detail']['eventDescription'][0]['latestDescription']  + "\n\n<https://phd.aws.amazon.com/phd/home?region=us-east-1#/event-log?eventID=" + event['detail']['eventArn'] + "|Click here> for details.")
-    json.dumps(message)
+    decoded_message = bytes(message, "utf-8").decode("unicode_escape")
+    json.dumps(decoded_message)
     slack_message = {
         'channel': SLACK_CHANNEL,
-        'text': message
+        'text': decoded_message
     }
     logger.info(str(slack_message))
     

--- a/slack-notifier/cfn-templates/slack-notifier.json
+++ b/slack-notifier/cfn-templates/slack-notifier.json
@@ -91,12 +91,14 @@
                 "def handler(event, context): \n",
                 "  message =  str(event['detail']['eventDescription'][0]['latestDescription'] + \"\\n\\n<https://phd.aws.amazon.com/phd/home?region=us-east-1#/event-log?eventID=\" + event['detail']['eventArn'] + \"|Click here> for details.\") \n",
                 "  json.dumps(message) \n",
+                "  decoded_message = bytes(message, \"utf-8\").decode(\"unicode_escape\") \n"
+                "  json.dumps(decoded_message) \n"
                 "  slack_message = { \n",
                 "    'channel': '",
                      {
                       "Ref": "SlackChannel"
                      },
-                "',\n    'text': message \n",
+                "',\n    'text': decoded_message \n",
                 "} \n",
                 "  logger.info(str(slack_message)) \n",
 

--- a/slack-notifier/cfn-templates/slack-notifier.yml
+++ b/slack-notifier/cfn-templates/slack-notifier.yml
@@ -73,7 +73,7 @@ Resources:
                 json.dumps(decoded_message)
                 slack_message = {
                   "channel": "${SlackChannel}",
-                  "text": message,
+                  "text": decoded_message,
                   "username": "AWS - Personal Health Updates"
                 }
                 logger.info(str(slack_message))

--- a/slack-notifier/cfn-templates/slack-notifier.yml
+++ b/slack-notifier/cfn-templates/slack-notifier.yml
@@ -69,7 +69,8 @@ Resources:
                     event['detail']['eventArn'] +
                     "|Click here> for details."
                 )
-                json.dumps(message)
+                decoded_message = bytes(message, "utf-8").decode("unicode_escape")
+                json.dumps(decoded_message)
                 slack_message = {
                   "channel": "${SlackChannel}",
                   "text": message,


### PR DESCRIPTION
- Added unicode decode to AWS health messages
- ex)
  - "MSK will patch the underlying operating system of brokers in your MSK cluster(s) with the latest OS updates between ....`\\n`   2. ...`\\n\\n`(1) https://docs.aws.amazon.com/msk/latest/developerguide/msk-get-bootstrap-brokers.html `\\n`(2) https://aws.amazon.com/support"
  - Added decode method to handle unicode (`\\n`, etc) in messages received from aws health