### PR TITLE
Allow to use "_.+-" in Email address

### DIFF
--- a/dx-maintenance-notifier/DX_Notifier.json
+++ b/dx-maintenance-notifier/DX_Notifier.json
@@ -4,7 +4,7 @@
     "EmailAddress": {
 	  "Description": "Please enter an email address to subscribe to the SNS topic. To subscribe additional email addresses and for other subscription options, go to SNS >> Topics >> \"DXMaintNotify\" >> Create subscription",
       "Type": "String",
-	  "AllowedPattern": "[a-zA-Z0-9]+@[0-9a-zA-Z]+\\.[a-zA-Z]+",
+	  "AllowedPattern": "[\-a-zA-Z0-9]+@[0-9a-zA-Z]+\\.[a-zA-Z]+",
 	  "ConstraintDescription": "Please enter a valid email address for the SNS subscription"
     }
   },    

--- a/dx-maintenance-notifier/DX_Notifier.json
+++ b/dx-maintenance-notifier/DX_Notifier.json
@@ -4,7 +4,7 @@
     "EmailAddress": {
 	  "Description": "Please enter an email address to subscribe to the SNS topic. To subscribe additional email addresses and for other subscription options, go to SNS >> Topics >> \"DXMaintNotify\" >> Create subscription",
       "Type": "String",
-	  "AllowedPattern": "[\-a-zA-Z0-9]+@[0-9a-zA-Z]+\\.[a-zA-Z]+",
+	  "AllowedPattern": "[a-zA-Z0-9_.+-]+@[0-9a-zA-Z]+\\.[a-zA-Z]+",
 	  "ConstraintDescription": "Please enter a valid email address for the SNS subscription"
     }
   },    

--- a/dx-maintenance-notifier/DX_Notifier.json
+++ b/dx-maintenance-notifier/DX_Notifier.json
@@ -4,7 +4,7 @@
     "EmailAddress": {
 	  "Description": "Please enter an email address to subscribe to the SNS topic. To subscribe additional email addresses and for other subscription options, go to SNS >> Topics >> \"DXMaintNotify\" >> Create subscription",
       "Type": "String",
-	  "AllowedPattern": "[a-zA-Z0-9_.+-]+@[0-9a-zA-Z]+\\.[a-zA-Z]+",
+	  "AllowedPattern": "[a-zA-Z0-9_.+-]+@([a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\\.)+[a-zA-Z]+",
 	  "ConstraintDescription": "Please enter a valid email address for the SNS subscription"
     }
   },    


### PR DESCRIPTION
Allow to use "_.+-"  in Email address and fix to use "." twice or over as the domain  like foo-bar@example.com.au

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
