### PR TITLE
make cfn json template consistent with its yaml equivalent

### DIFF
--- a/slack-notifier/LambdaFunction.py
+++ b/slack-notifier/LambdaFunction.py
@@ -1,5 +1,5 @@
 '''
-This is a sample function to send AWS Health event messages to a Slack channel. 
+This is a sample function to send AWS Health event messages to a Slack channel.
 
 Follow these steps to configure the webhook in Slack:
 
@@ -15,42 +15,48 @@ You can also use KMS to encrypt the webhook URL as shown here: https://aws.amazo
 '''
 
 from __future__ import print_function
-
 import boto3
 import json
 import logging
 import os
-
-from urllib2 import Request, urlopen, URLError, HTTPError
+from urllib.request import Request, urlopen, URLError, HTTPError
+from urllib.parse import urlencode
 
 #configuration
 
 # The Slack channel to send a message to stored in the slackChannel environment variable
-SLACK_CHANNEL = "#awshealth"
+SLACK_CHANNEL = '#awshealth'
 # Add the webhook URL from Slack below
-HOOK_URL = "https://hooks.slack.com/services/example"
+HOOK_URL = 'https://hooks.slack.com/services/example'
 # Setting up logging
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-
-#main function
-
-def lambda_handler(event, context):
-    message =  str(event['detail']['eventDescription'][0]['latestDescription']  + "\n\n<https://phd.aws.amazon.com/phd/home?region=us-east-1#/event-log?eventID=" + event['detail']['eventArn'] + "|Click here> for details.")
+# main function
+def handler(event, context):
+    message =  str(
+        event['detail']['eventDescription'][0]['latestDescription']  +
+        '\n\n<https://phd.aws.amazon.com/phd/home?region=us-east-1#/event-log?eventID=' +
+        event['detail']['eventArn'] +
+        '|Click here> for details.'
+    )
     json.dumps(message)
     slack_message = {
         'channel': SLACK_CHANNEL,
-        'text': message
+        'text': message,
+        'username': 'AWS - Personal Health Updates'
     }
     logger.info(str(slack_message))
-    
-    req = Request(HOOK_URL, json.dumps(slack_message))
+    req = Request(
+        HOOK_URL,
+        data=json.dumps(slack_message).encode('utf-8'),
+        headers={'content-type': 'application/json'}
+    )
     try:
         response = urlopen(req)
         response.read()
-        logger.info("Message posted to %s", slack_message['channel'])
+        logger.info('Message posted to: %s', slack_message['channel'])
     except HTTPError as e:
-        logger.error("Request failed: %d %s", e.code, e.reason)
+        logger.error('Request failed : %d %s', e.code, e.reason)
     except URLError as e:
-        logger.error("Server connection failed: %s", e.reason)
+        logger.error('Server connection failed: %s', e.reason)
 

--- a/slack-notifier/cfn-templates/slack-notifier.json
+++ b/slack-notifier/cfn-templates/slack-notifier.json
@@ -7,7 +7,8 @@
     },
     "HookURL": {
       "Type": "String",
-      "Description": "Please enter the web hook url from Slack:"
+      "Description": "Please enter the web hook url from Slack:",
+      "NoEcho": true
     }
   },
   "Resources": {
@@ -62,6 +63,7 @@
     "SlackNotifierLambdaFn": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
+        "Description": "AWS PHD Slack Notifier",
         "Handler": "index.handler",
         "Role": {
           "Fn::GetAtt": [
@@ -71,49 +73,10 @@
         },
         "Code": {
           "ZipFile": {
-            "Fn::Join": [
-              "",
-              [
-                "#Sample Lambda Function to post notifications to a slack channel when an AWS Health event happens\n",
-                "from __future__ import print_function \n",
-                "import boto3 \n",
-                "import json \n",
-                "import logging \n",
-                "import os \n",
-                "from urllib2 import Request, urlopen, URLError, HTTPError \n",
-
-                "# Setting up logging \n",
-                "logger = logging.getLogger() \n",
-                "logger.setLevel(logging.INFO) \n",
-
-                "# main function \n",
-
-                "def handler(event, context): \n",
-                "  message =  str(event['detail']['eventDescription'][0]['latestDescription'] + \"\\n\\n<https://phd.aws.amazon.com/phd/home?region=us-east-1#/event-log?eventID=\" + event['detail']['eventArn'] + \"|Click here> for details.\") \n",
-                "  json.dumps(message) \n",
-                "  slack_message = { \n",
-                "    'channel': '",
-                     {
-                      "Ref": "SlackChannel"
-                     },
-                "',\n    'text': message \n",
-                "} \n",
-                "  logger.info(str(slack_message)) \n",
-
-                "  req = Request(\"",{"Ref":"HookURL"}, "\", json.dumps(slack_message)) \n",
-                "  try: \n",
-                "   response = urlopen(req) \n",
-                "   response.read() \n",
-                "   logger.info(\"Message posted to %s\", slack_message['channel']) \n",
-                "  except HTTPError as e: \n",
-                "   logger.error(\"Request failed : %d %s\", e.code, e.reason) \n",
-                "  except URLError as e: \n",
-                "   logger.error(\"Server connection failed: %s\", e.reason) \n"
-              ]
-            ]
+            "Fn::Sub": "# Sample Lambda Function to post notifications to a slack channel when an AWS Health event happens\nfrom __future__ import print_function\nimport boto3\nimport json\nimport logging\nimport os\nfrom urllib.request import Request, urlopen, URLError, HTTPError\nfrom urllib.parse import urlencode\n# Setting up logging\nlogger = logging.getLogger()\nlogger.setLevel(logging.INFO)\n# main function\ndef handler(event, context):\n    message =  str(\n        event['detail']['eventDescription'][0]['latestDescription']  +\n        \"\\n\\n<https://phd.aws.amazon.com/phd/home?region=us-east-1#/event-log?eventID=\" +\n        event['detail']['eventArn'] +\n        \"|Click here> for details.\"\n    )\n    json.dumps(message)\n    slack_message = {\n      \"channel\": \"${SlackChannel}\",\n      \"text\": message,\n      \"username\": \"AWS - Personal Health Updates\"\n    }\n    logger.info(str(slack_message))\n    req = Request(\n      \"${HookURL}\",\n      data=json.dumps(slack_message).encode(\"utf-8\"),\n      headers={\"content-type\": \"application/json\"}\n    )\n    try:\n      response = urlopen(req)\n      response.read()\n      logger.info(\"Message posted to: %s\", slack_message['channel'])\n    except HTTPError as e:\n       logger.error(\"Request failed : %d %s\", e.code, e.reason)\n    except URLError as e:\n       logger.error(\"Server connection failed: %s\", e.reason)\n"
           }
         },
-        "Runtime": "python2.7",
+        "Runtime": "python3.7",
         "Timeout": "60"
       }
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

JSON cfn template is no longer working because of python2.7 runtime has been deprecated, this PR is for updating the template as well as the source code for the one available in the yaml cf template which is compatible with python3.7 runtime


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
