### PR TITLE
Added all eventcodes for IAM KEYS EXPOSED

### DIFF
--- a/automated-actions/AWS_RISK_CREDENTIALS_EXPOSED/cloudformation/risk_credentials_exposed.serverless.yaml
+++ b/automated-actions/AWS_RISK_CREDENTIALS_EXPOSED/cloudformation/risk_credentials_exposed.serverless.yaml
@@ -17,7 +17,11 @@ Resources:
           eventTypeCategory:
             - "issue"
           eventTypeCode:
+            - "AWS_RISK_CREDENTIALS_COMPROMISED"
+            - "AWS_RISK_CREDENTIALS_COMPROMISE_SUSPECTED"
             - "AWS_RISK_CREDENTIALS_EXPOSED"
+            - "AWS_RISK_CREDENTIALS_EXPOSURE_SUSPECTED"
+            - "AWS_RISK_IAM_QUARANTINE"
       State: "ENABLED"
       Targets: 
         - 


### PR DESCRIPTION
*Issue #, if available:*
The current CFT is tracking only "AWS_RISK_CREDENTIALS_EXPOSED" eventype code. But it will be helpful if this workflow works for all the below eventcodes - 
           "category": "issue", 
            "code": "AWS_RISK_CREDENTIALS_COMPROMISED", 
            "service": "RISK"
        }, 
        {
            "category": "issue", 
            "code": "AWS_RISK_CREDENTIALS_COMPROMISE_SUSPECTED", 
            "service": "RISK"
        }, 
        {
            "category": "issue", 
            "code": "AWS_RISK_CREDENTIALS_EXPOSED", 
            "service": "RISK"
        }, 
        {
            "category": "issue", 
            "code": "AWS_RISK_CREDENTIALS_EXPOSURE_SUSPECTED", 
            "service": "RISK"

*Description of changes:*

Added new eventcodes for IAM RISK EXPOSED issue


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
