### PR TITLE
all_events.json

### DIFF
--- a/all_events.json
+++ b/all_events.json
@@ -1,0 +1,7374 @@
+{
+    "eventTypes": [
+        {
+            "service": "A2I",
+            "code": "AWS_A2I_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "A2I",
+            "code": "AWS_A2I_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "A2I",
+            "code": "AWS_A2I_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_BOTNET_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_CC_FRAUD_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_CONFIGURATION_REVIEW",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_COPYRIGHT_DMCA_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_COPYRIGHT_NON_DMCA_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_DOS_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_EMAIL_SPAM_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_EXTREMIST_VIOLENT_CONTENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_FORUM_SPAM_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_HATE_SPEECH",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_ILLEGAL_CONTENT_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_INTRUSION_ATTEMPT_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_IP_CYCLING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_MALWARE_WEBSITE_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_OPEN_PROXY_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_PHISHING_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_PII_CONTENT_REMOVAL_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_PORT_SCANNING_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_PUBLICLY_AVAILABLE_INFORMATION_REPORT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_SPAM_WEBSITE_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_TAKEDOWN_REQUEST_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ABUSE",
+            "code": "AWS_ABUSE_WEBCRAWL_REPORT",
+            "category": "issue"
+        },
+        {
+            "service": "ACCOUNT",
+            "code": "AWS_ACCOUNT_CUSTOMER_VERIFICATION_FAILED",
+            "category": "issue"
+        },
+        {
+            "service": "ACCOUNT",
+            "code": "AWS_ACCOUNT_CUSTOMER_VERIFICATION_NOT_REQUIRED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ACCOUNT",
+            "code": "AWS_ACCOUNT_CUSTOMER_VERIFICATION_REQUIRED",
+            "category": "issue"
+        },
+        {
+            "service": "ACCOUNT",
+            "code": "AWS_ACCOUNT_CUSTOMER_VERIFICATION_SUCCESS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ACCOUNT",
+            "code": "AWS_ACCOUNT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ACCOUNT",
+            "code": "AWS_ACCOUNT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ACCOUNT",
+            "code": "AWS_ACCOUNT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_API_FAULT",
+            "category": "issue"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_CONSOLE_ERRORS",
+            "category": "issue"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_CONSOLE_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_CREATE_CERTIFICATE_AUTHORITY_AUDIT_REPORT_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_CREATE_CERTIFICATE_AUTHORITY_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_CRL_UPDATE_DELAY",
+            "category": "issue"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_ISSUE_CERTIFICATE_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ACMPRIVATECA",
+            "code": "AWS_ACMPRIVATECA_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ACM",
+            "code": "AWS_ACM_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ACM",
+            "code": "AWS_ACM_CAA_CHECK_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "ACM",
+            "code": "AWS_ACM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ACM",
+            "code": "AWS_ACM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ACM",
+            "code": "AWS_ACM_RENEWAL_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "ACM",
+            "code": "AWS_ACM_RENEWAL_STATE_CHANGE",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "ACM",
+            "code": "AWS_ACM_RENEWED_CUSTOMER",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "ACM",
+            "code": "AWS_ACM_RENEWED_PARTNER",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "ACM",
+            "code": "AWS_ACM_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ACTIVATECONSOLE",
+            "code": "AWS_ACTIVATECONSOLE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ACTIVATECONSOLE",
+            "code": "AWS_ACTIVATECONSOLE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AIRFLOW",
+            "code": "AWS_AIRFLOW_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "AIRFLOW",
+            "code": "AWS_AIRFLOW_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AIRFLOW",
+            "code": "AWS_AIRFLOW_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AIRFLOW",
+            "code": "AWS_AIRFLOW_UNHEALTHY_SCHEDULERS",
+            "category": "issue"
+        },
+        {
+            "service": "AIRFLOW",
+            "code": "AWS_AIRFLOW_UNHEALTHY_WORKERS",
+            "category": "issue"
+        },
+        {
+            "service": "AMPLIFYADMIN",
+            "code": "AWS_AMPLIFYADMIN_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "AMPLIFYADMIN",
+            "code": "AWS_AMPLIFYADMIN_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AMPLIFYUIBUILDER",
+            "code": "AWS_AMPLIFYUIBUILDER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "AMPLIFYUIBUILDER",
+            "code": "AWS_AMPLIFYUIBUILDER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AMPLIFY",
+            "code": "AWS_AMPLIFY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "AMPLIFY",
+            "code": "AWS_AMPLIFY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AMPLIFY",
+            "code": "AWS_AMPLIFY_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APIGATEWAY",
+            "code": "AWS_APIGATEWAY_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APIGATEWAY",
+            "code": "AWS_APIGATEWAY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APIGATEWAY",
+            "code": "AWS_APIGATEWAY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APIGATEWAY",
+            "code": "AWS_APIGATEWAY_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPCONFIG",
+            "code": "AWS_APPCONFIG_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPCONFIG",
+            "code": "AWS_APPCONFIG_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPFABRIC",
+            "code": "AWS_APPFABRIC_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPFABRIC",
+            "code": "AWS_APPFABRIC_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "APPFABRIC",
+            "code": "AWS_APPFABRIC_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "APPFABRIC",
+            "code": "AWS_APPFABRIC_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPFABRIC",
+            "code": "AWS_APPFABRIC_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPFLOW",
+            "code": "AWS_APPFLOW_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPFLOW",
+            "code": "AWS_APPFLOW_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPLICATIONINSIGHTS",
+            "code": "AWS_APPLICATIONINSIGHTS_INCOMPLETE_CONFIGURATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPLICATIONINSIGHTS",
+            "code": "AWS_APPLICATIONINSIGHTS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPLICATIONINSIGHTS",
+            "code": "AWS_APPLICATIONINSIGHTS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPLICATION_AUTOSCALING",
+            "code": "AWS_APPLICATION_AUTOSCALING_DYNAMODB_ACCOUNT_READ_CAPACITY_EXCEEDED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPLICATION_AUTOSCALING",
+            "code": "AWS_APPLICATION_AUTOSCALING_DYNAMODB_ACCOUNT_WRITE_CAPACITY_EXCEEDED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPLICATION_AUTOSCALING",
+            "code": "AWS_APPLICATION_AUTOSCALING_DYNAMODB_TABLE_READ_CAPACITY_EXCEEDED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPLICATION_AUTOSCALING",
+            "code": "AWS_APPLICATION_AUTOSCALING_DYNAMODB_TABLE_WRITE_CAPACITY_EXCEEDED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPMESH",
+            "code": "AWS_APPMESH_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPMESH",
+            "code": "AWS_APPMESH_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPRUNNER",
+            "code": "AWS_APPRUNNER_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "APPRUNNER",
+            "code": "AWS_APPRUNNER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPRUNNER",
+            "code": "AWS_APPRUNNER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_AD_CREDENTIALS_EXPIRED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_DNS_AD_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_DNS_MANAGEMENT_SERVERS_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_FLEET_STOPPED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_SESSION_PROVISION_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPSTREAM2",
+            "code": "AWS_APPSTREAM2_STREAMING_CONNECTION_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "APPSTREAM",
+            "code": "AWS_APPSTREAM_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPSTREAM",
+            "code": "AWS_APPSTREAM_BILLING_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSTREAM",
+            "code": "AWS_APPSTREAM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPSTREAM",
+            "code": "AWS_APPSTREAM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSYNC",
+            "code": "AWS_APPSYNC_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APPSYNC",
+            "code": "AWS_APPSYNC_GATEWAY_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPSYNC",
+            "code": "AWS_APPSYNC_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APPSYNC",
+            "code": "AWS_APPSYNC_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "APS",
+            "code": "AWS_APS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "APS",
+            "code": "AWS_APS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ATHENA",
+            "code": "AWS_ATHENA_DDL_UPGRADE_REACHOUT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ATHENA",
+            "code": "AWS_ATHENA_ENGINE_VERSION_AUTO_UPGRADE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ATHENA",
+            "code": "AWS_ATHENA_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ATHENA",
+            "code": "AWS_ATHENA_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AUDITMANAGER",
+            "code": "AWS_AUDITMANAGER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "AUDITMANAGER",
+            "code": "AWS_AUDITMANAGER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AUDITMANAGER",
+            "code": "AWS_AUDITMANAGER_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AUTOSCALING",
+            "code": "AWS_AUTOSCALING_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "AUTOSCALING",
+            "code": "AWS_AUTOSCALING_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AUTOSCALING",
+            "code": "AWS_AUTOSCALING_INCREASED_LAUNCH_ERRORS",
+            "category": "issue"
+        },
+        {
+            "service": "AUTOSCALING",
+            "code": "AWS_AUTOSCALING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "AUTOSCALING",
+            "code": "AWS_AUTOSCALING_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AUTOSCALING",
+            "code": "AWS_AUTOSCALING_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "AWIS",
+            "code": "AWS_AWIS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BACKUP",
+            "code": "AWS_BACKUP_CONSOLE_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "BACKUP",
+            "code": "AWS_BACKUP_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BACKUP",
+            "code": "AWS_BACKUP_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "BACKUP",
+            "code": "AWS_BACKUP_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BACKUP",
+            "code": "AWS_BACKUP_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_AL1_AMI_DEPRECATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_INSTANCES_CLUSTER_JOIN_FAILED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_LIFECYCLE_IMPACT_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_POST_KUBE_DEPRECATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_PRE_KUBE_DEPRECATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_ROLE_MISSING_EC2_HEALTH_CHECK_PERMISSIONS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BATCH",
+            "code": "AWS_BATCH_STREAMING_IMPACT_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BEDROCK",
+            "code": "AWS_BEDROCK_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "BEDROCK",
+            "code": "AWS_BEDROCK_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BILLING",
+            "code": "AWS_BILLING_ACCOUNT_RESTRICTED_DUE_TO_NON_PAYMENT",
+            "category": "issue"
+        },
+        {
+            "service": "BILLING",
+            "code": "AWS_BILLING_CREDIT_CARD_PAYMENT_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "BILLING",
+            "code": "AWS_BILLING_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BILLING",
+            "code": "AWS_BILLING_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BILLING",
+            "code": "AWS_BILLING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "BILLING",
+            "code": "AWS_BILLING_PAYMENT_PORTAL_AVAILABILITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "BILLING",
+            "code": "AWS_BILLING_PAYMENT_POSTING_DELAYED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BILLING",
+            "code": "AWS_BILLING_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BILLING",
+            "code": "AWS_BILLING_SUSPENSION_NOTICE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "BRAKET",
+            "code": "AWS_BRAKET_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "BRAKET",
+            "code": "AWS_BRAKET_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CASSANDRA",
+            "code": "AWS_CASSANDRA_EAR_CREATE_TABLE_CANCELED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CASSANDRA",
+            "code": "AWS_CASSANDRA_EAR_INACCESSIBLE_TABLE_ENCRYPTION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CASSANDRA",
+            "code": "AWS_CASSANDRA_EAR_TABLE_DELETED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CASSANDRA",
+            "code": "AWS_CASSANDRA_MULTI_REGION_OPERATION_ABORTED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CASSANDRA",
+            "code": "AWS_CASSANDRA_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CASSANDRA",
+            "code": "AWS_CASSANDRA_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CHATBOT",
+            "code": "AWS_CHATBOT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CHATBOT",
+            "code": "AWS_CHATBOT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CHATBOT",
+            "code": "AWS_CHATBOT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CHIME",
+            "code": "AWS_CHIME_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CHIME",
+            "code": "AWS_CHIME_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_CLASSIC_VPN_IDLE_CONNECTIONS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_CLASSIC_VPN_IDLE_CONNECTIONS_JP",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_CLASSIC_VPN_TERMINATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_CLASSIC_VPN_TERMINATION_RISK",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_CLASSIC_VPN_TERMINATION_RISK_JP",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_CLASSIC_VPN_TUNNEL_TERMINATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLEANROOMS",
+            "code": "AWS_CLEANROOMS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLEANROOMS",
+            "code": "AWS_CLEANROOMS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLIENT_VPN",
+            "code": "AWS_CLIENT_VPN_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLIENT_VPN",
+            "code": "AWS_CLIENT_VPN_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLIENT_VPN",
+            "code": "AWS_CLIENT_VPN_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUD9",
+            "code": "AWS_CLOUD9_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUD9",
+            "code": "AWS_CLOUD9_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUD9",
+            "code": "AWS_CLOUD9_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDDIRECTORY",
+            "code": "AWS_CLOUDDIRECTORY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDDIRECTORY",
+            "code": "AWS_CLOUDDIRECTORY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDFORMATION",
+            "code": "AWS_CLOUDFORMATION_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFORMATION",
+            "code": "AWS_CLOUDFORMATION_INCREASED_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFORMATION",
+            "code": "AWS_CLOUDFORMATION_INCREASED_STACK_CREATE_DELETE_UPDATE_TIMES",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFORMATION",
+            "code": "AWS_CLOUDFORMATION_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFORMATION",
+            "code": "AWS_CLOUDFORMATION_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDFORMATION",
+            "code": "AWS_CLOUDFORMATION_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDFORMATION",
+            "code": "AWS_CLOUDFORMATION_TEMPLATE_ERRORS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFRONT",
+            "code": "AWS_CLOUDFRONT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFRONT",
+            "code": "AWS_CLOUDFRONT_CHANGE_PROPAGATION_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFRONT",
+            "code": "AWS_CLOUDFRONT_INCREASED_DNS_ERRORS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFRONT",
+            "code": "AWS_CLOUDFRONT_INCREASED_MANAGEMENT_CONSOLE_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFRONT",
+            "code": "AWS_CLOUDFRONT_INVALIDATIONS_PROPAGATION_DELAY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFRONT",
+            "code": "AWS_CLOUDFRONT_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "CLOUDFRONT",
+            "code": "AWS_CLOUDFRONT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDFRONT",
+            "code": "AWS_CLOUDFRONT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDFRONT",
+            "code": "AWS_CLOUDFRONT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_BILLING_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_CLIENT_DEPRECATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_CLIENT_VERSION_ALERT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_NETWORK_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDHSM",
+            "code": "AWS_CLOUDHSM_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDSEARCH",
+            "code": "AWS_CLOUDSEARCH_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDSEARCH",
+            "code": "AWS_CLOUDSEARCH_DOMAIN_CREATION_INDEXING_OPERATIONS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDSEARCH",
+            "code": "AWS_CLOUDSEARCH_INDEXDOCUMENTS_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDSEARCH",
+            "code": "AWS_CLOUDSEARCH_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDSEARCH",
+            "code": "AWS_CLOUDSEARCH_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDSHELL",
+            "code": "AWS_CLOUDSHELL_CREATE_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDSHELL",
+            "code": "AWS_CLOUDSHELL_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDSHELL",
+            "code": "AWS_CLOUDSHELL_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDSHELL",
+            "code": "AWS_CLOUDSHELL_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDSHELL",
+            "code": "AWS_CLOUDSHELL_PERSISTENCE_EXPIRING",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "CLOUDSHELL",
+            "code": "AWS_CLOUDSHELL_START_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDTRAIL",
+            "code": "AWS_CLOUDTRAIL_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDTRAIL",
+            "code": "AWS_CLOUDTRAIL_EVENT_DELIVERY_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDTRAIL",
+            "code": "AWS_CLOUDTRAIL_INCREASED_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDTRAIL",
+            "code": "AWS_CLOUDTRAIL_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDTRAIL",
+            "code": "AWS_CLOUDTRAIL_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDTRAIL",
+            "code": "AWS_CLOUDTRAIL_S3_DELIVERY_ERROR",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDTRAIL",
+            "code": "AWS_CLOUDTRAIL_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDTRAIL",
+            "code": "AWS_CLOUDTRAIL_SNS_DELIVERY_ERROR",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWAN",
+            "code": "AWS_CLOUDWAN_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWAN",
+            "code": "AWS_CLOUDWAN_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWAN",
+            "code": "AWS_CLOUDWAN_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWAN",
+            "code": "AWS_CLOUDWAN_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDWATCHSYNTHETICS",
+            "code": "AWS_CLOUDWATCHSYNTHETICS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCHSYNTHETICS",
+            "code": "AWS_CLOUDWATCHSYNTHETICS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDWATCHSYNTHETICS",
+            "code": "AWS_CLOUDWATCHSYNTHETICS_TRANSIT_CANARIES_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_ALARMS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_ALARMS_COMPOSITEALARM_PROCESSING_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_ALARMS_HISTORY_UPDATE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_ALARMS_PROCESSING_FAILURES",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_ALARM_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_DELAYED_METRICS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_LOGS_DESCRIBELOGGROUPS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_LOGS_GETLOGEVENTS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_LOGS_INSIGHTS_INDEXING_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_METRICS_GETMETRICDATA_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_METRICS_GETMETRICSTATISTICS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_METRICS_INCREASED_GETMETRICDATA_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_METRICS_INCREASED_GETMETRICSTATISTICS_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_METRICS_INCREASED_PUTMETRICDATA_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CLOUDWATCH",
+            "code": "AWS_CLOUDWATCH_SYNTHETICS_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEARTIFACT",
+            "code": "AWS_CODEARTIFACT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEARTIFACT",
+            "code": "AWS_CODEARTIFACT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODEBUILD",
+            "code": "AWS_CODEBUILD_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEBUILD",
+            "code": "AWS_CODEBUILD_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODEBUILD",
+            "code": "AWS_CODEBUILD_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODECATALYST",
+            "code": "AWS_CODECATALYST_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODECATALYST",
+            "code": "AWS_CODECATALYST_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODECOMMIT",
+            "code": "AWS_CODECOMMIT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODECOMMIT",
+            "code": "AWS_CODECOMMIT_HTTPS_DATA_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODECOMMIT",
+            "code": "AWS_CODECOMMIT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODECOMMIT",
+            "code": "AWS_CODECOMMIT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODEDEPLOY",
+            "code": "AWS_CODEDEPLOY_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEDEPLOY",
+            "code": "AWS_CODEDEPLOY_INCREASED_DEPLOYMENT_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "CODEDEPLOY",
+            "code": "AWS_CODEDEPLOY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEDEPLOY",
+            "code": "AWS_CODEDEPLOY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODEDEPLOY",
+            "code": "AWS_CODEDEPLOY_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODEGURU_PROFILER",
+            "code": "AWS_CODEGURU_PROFILER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEGURU_REVIEWER",
+            "code": "AWS_CODEGURU_REVIEWER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEGURU_REVIEWER",
+            "code": "AWS_CODEGURU_REVIEWER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_ACTION_DEFINITION_API_FAULT_RATE_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_ACTION_DEFINITION_API_LATENCY_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_ACTION_EXECUTION_API_FAULT_RATE_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_ACTION_EXECUTION_API_LATENCY_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_NOT_DETECTING_NEW_SOURCE_REVISIONS_AUTOMATION_DELAYED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_PIPELINE_DEFINITION_API_FAULT_RATE_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_PIPELINE_DEFINITION_API_LATENCY_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_PIPELINE_EXECUTION_API_FAULT_RATE_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_PIPELINE_EXECUTION_API_LATENCY_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_PIPELINE_EXECUTION_DELAYED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_TRIGGER_WEBHOOK_API_FAULT_RATE_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_TRIGGER_WEBHOOK_API_LATENCY_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_WEBHOOK_API_FAULT_RATE_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODEPIPELINE",
+            "code": "AWS_CODEPIPELINE_WEBHOOK_API_LATENCY_THRESHOLD_EXCEEDED",
+            "category": "issue"
+        },
+        {
+            "service": "CODESTAR",
+            "code": "AWS_CODESTAR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODESTAR",
+            "code": "AWS_CODESTAR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODESTAR",
+            "code": "AWS_CODESTAR_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CODEWHISPERER",
+            "code": "AWS_CODEWHISPERER_GENERATECOMPLETIONS_FAILURES",
+            "category": "issue"
+        },
+        {
+            "service": "CODEWHISPERER",
+            "code": "AWS_CODEWHISPERER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CODEWHISPERER",
+            "code": "AWS_CODEWHISPERER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_APPROACHING_DATASET_COUNT_LIMIT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_APPROACHING_IDENTITY_POOL_COUNT_LIMIT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_APPROACHING_USER_POOL_CLIENT_COUNT_LIMIT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_APPROACHING_USER_POOL_COUNT_LIMIT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_CREATE_IDENTITY_POOL_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_DATASET_COUNT_LIMIT_REACHED",
+            "category": "issue"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_DELETE_IDENTITY_POOL_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_EMAIL_BOUNCE_WARNING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_EMAIL_FINAL_WARNING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_EMAIL_LIMIT_REDUCED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_HOSTED_UI_ENDPOINT_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_IDENTITY_POOL_COUNT_LIMIT_REACHED",
+            "category": "issue"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_ISSUES_WITH_STREAMS_ROLE",
+            "category": "issue"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_USER_POOL_CLIENT_COUNT_LIMIT_REACHED",
+            "category": "issue"
+        },
+        {
+            "service": "COGNITO",
+            "code": "AWS_COGNITO_USER_POOL_COUNT_LIMIT_REACHED",
+            "category": "issue"
+        },
+        {
+            "service": "COMPREHENDMEDICAL",
+            "code": "AWS_COMPREHENDMEDICAL_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "COMPREHENDMEDICAL",
+            "code": "AWS_COMPREHENDMEDICAL_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COMPREHEND",
+            "code": "AWS_COMPREHEND_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "COMPREHEND",
+            "code": "AWS_COMPREHEND_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COMPUTE_OPTIMIZER",
+            "code": "AWS_COMPUTE_OPTIMIZER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "COMPUTE_OPTIMIZER",
+            "code": "AWS_COMPUTE_OPTIMIZER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CONFIG",
+            "code": "AWS_CONFIG_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CONFIG",
+            "code": "AWS_CONFIG_INCREASED_LATENCIES_CAPTURING_CONFIGURATION_CHANGES",
+            "category": "issue"
+        },
+        {
+            "service": "CONFIG",
+            "code": "AWS_CONFIG_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CONFIG",
+            "code": "AWS_CONFIG_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CONNECT",
+            "code": "AWS_CONNECT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CONNECT",
+            "code": "AWS_CONNECT_CASES_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CONNECT",
+            "code": "AWS_CONNECT_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CONNECT",
+            "code": "AWS_CONNECT_DIRECTORY_SIGNIN_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "CONNECT",
+            "code": "AWS_CONNECT_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "CONNECT",
+            "code": "AWS_CONNECT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CONNECT",
+            "code": "AWS_CONNECT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CONNECT",
+            "code": "AWS_CONNECT_SAML_SIGNIN_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "CONNECT",
+            "code": "AWS_CONNECT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CONSOLEMOBILEAPP",
+            "code": "AWS_CONSOLEMOBILEAPP_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CONSOLEMOBILEAPP",
+            "code": "AWS_CONSOLEMOBILEAPP_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CONSOLEMOBILEAPP",
+            "code": "AWS_CONSOLEMOBILEAPP_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CONTROLTOWER",
+            "code": "AWS_CONTROLTOWER_CREATE_LANDING_ZONE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CONTROLTOWER",
+            "code": "AWS_CONTROLTOWER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "CONTROLTOWER",
+            "code": "AWS_CONTROLTOWER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CONTROLTOWER",
+            "code": "AWS_CONTROLTOWER_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "CORRETTO",
+            "code": "AWS_CORRETTO_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "COSTPLANNER",
+            "code": "AWS_COSTPLANNER_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "COSTPLANNER",
+            "code": "AWS_COSTPLANNER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "COSTPLANNER",
+            "code": "AWS_COSTPLANNER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DATABREW",
+            "code": "AWS_DATABREW_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DATAEXCHANGE",
+            "code": "AWS_DATAEXCHANGE_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DATAEXCHANGE",
+            "code": "AWS_DATAEXCHANGE_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "DATAEXCHANGE",
+            "code": "AWS_DATAEXCHANGE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DATAEXCHANGE",
+            "code": "AWS_DATAEXCHANGE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DATAEXCHANGE",
+            "code": "AWS_DATAEXCHANGE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DATAPIPELINE",
+            "code": "AWS_DATAPIPELINE_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DATAPIPELINE",
+            "code": "AWS_DATAPIPELINE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DATAPIPELINE",
+            "code": "AWS_DATAPIPELINE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DATAPIPELINE",
+            "code": "AWS_DATAPIPELINE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_DISCOVERY_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_DISCOVERY_JOB_BATCH_COLLECTION_FAILURES",
+            "category": "issue"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_DISCOVERY_JOB_BATCH_FAILURES",
+            "category": "issue"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_DISCOVERY_JOB_EXECUTION_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_STUCK_TASK_EXECUTION_ISSUES",
+            "category": "issue"
+        },
+        {
+            "service": "DATASYNC",
+            "code": "AWS_DATASYNC_TASK_EXECUTION_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DAX",
+            "code": "AWS_DAX_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DAX",
+            "code": "AWS_DAX_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DAX",
+            "code": "AWS_DAX_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DEEPCOMPOSER",
+            "code": "AWS_DEEPCOMPOSER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DEEPCOMPOSER",
+            "code": "AWS_DEEPCOMPOSER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DEEPLENS",
+            "code": "AWS_DEEPLENS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DEEPLENS",
+            "code": "AWS_DEEPLENS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DEEPRACER",
+            "code": "AWS_DEEPRACER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DEEPRACER",
+            "code": "AWS_DEEPRACER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DEEPRACER",
+            "code": "AWS_DEEPRACER_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DETECTIVE",
+            "code": "AWS_DETECTIVE_DELEGATED_ADMINISTRATOR_PERMISSIONS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DETECTIVE",
+            "code": "AWS_DETECTIVE_DISABLED_ALL_INGESTION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DETECTIVE",
+            "code": "AWS_DETECTIVE_DISABLED_OPTIONAL_DATASOURCES_INGESTION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DETECTIVE",
+            "code": "AWS_DETECTIVE_HIGH_VOLUME_ENTITY",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DETECTIVE",
+            "code": "AWS_DETECTIVE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DETECTIVE",
+            "code": "AWS_DETECTIVE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DETECTIVE",
+            "code": "AWS_DETECTIVE_ORG_MANAGER_PERMISSIONS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DETECTIVE",
+            "code": "AWS_DETECTIVE_SERVICE_ENABLEMENT_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "DEVICEFARM",
+            "code": "AWS_DEVICEFARM_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DEVICEFARM",
+            "code": "AWS_DEVICEFARM_DEVICE_SLOT_CANCELLATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DEVICEFARM",
+            "code": "AWS_DEVICEFARM_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "DEVICEFARM",
+            "code": "AWS_DEVICEFARM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DEVICEFARM",
+            "code": "AWS_DEVICEFARM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DEVICEFARM",
+            "code": "AWS_DEVICEFARM_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DEVOPS-GURU",
+            "code": "AWS_DEVOPS-GURU_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DEVOPS-GURU",
+            "code": "AWS_DEVOPS-GURU_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DEVOPS-GURU",
+            "code": "AWS_DEVOPS-GURU_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIODE",
+            "code": "AWS_DIODE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DIODE",
+            "code": "AWS_DIODE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_BILLING_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_CONNECTION_NEWREQUEST_FOLLOWUP",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_CONNECTION_TURNUP_FOLLOWUP",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_EMERGENCY_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_HIGH_AVAILABILITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_MAINTENANCE_CANCELLED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_MAINTENANCE_COMPLETE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_MAINTENANCE_EXTENSION",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_MAINTENANCE_FOLLOW_UP",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_PACKET_LOSS",
+            "category": "issue"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_PORT_UNAVAILABLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_REQUEST_FOR_ADDITIONAL_INFORMATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DIRECTCONNECT",
+            "code": "AWS_DIRECTCONNECT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DISCOVERY",
+            "code": "AWS_DISCOVERY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DISCOVERY",
+            "code": "AWS_DISCOVERY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DLM",
+            "code": "AWS_DLM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DLM",
+            "code": "AWS_DLM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DMS",
+            "code": "AWS_DMS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DMS",
+            "code": "AWS_DMS_END_OF_FREE_TIER",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DMS",
+            "code": "AWS_DMS_MAINTENANCE_MESSAGE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DMS",
+            "code": "AWS_DMS_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "DMS",
+            "code": "AWS_DMS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DMS",
+            "code": "AWS_DMS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DMS",
+            "code": "AWS_DMS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DMS",
+            "code": "AWS_DMS_WELCOME_MESSAGE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DOCDB",
+            "code": "AWS_DOCDB_HARDWARE_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "DOCDB",
+            "code": "AWS_DOCDB_INSTANCE_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DOCDB",
+            "code": "AWS_DOCDB_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "DOCDB",
+            "code": "AWS_DOCDB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DOCDB",
+            "code": "AWS_DOCDB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DOCDB",
+            "code": "AWS_DOCDB_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DRS",
+            "code": "AWS_DRS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DRS",
+            "code": "AWS_DRS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DS",
+            "code": "AWS_DS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DS",
+            "code": "AWS_DS_DEGRADED_AUTHENTICATION_PERFORMANCE",
+            "category": "issue"
+        },
+        {
+            "service": "DS",
+            "code": "AWS_DS_END_OF_FREE_TIER",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DS",
+            "code": "AWS_DS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DS",
+            "code": "AWS_DS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DS",
+            "code": "AWS_DS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_EAR_INACCESSIBLE_TABLE_ENCRYPTION",
+            "category": "issue"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_GT_INACCESSIBLE_CMCMK_REPLICA_DETECTED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_GT_INACCESSIBLE_CMCMK_REPLICA_REMOVED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_GT_WCU_MISMATCH",
+            "category": "issue"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_GT_WCU_MISMATCH_REPLICATION_THROTTLED",
+            "category": "issue"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_GT_WORKFLOW_FAILED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_KDSD_KMS_INACCESSIBLE_CREDENTIALS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_KDSD_STREAM_DISABLED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_KDSD_UNDER_PROVISIONING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "DYNAMODB",
+            "code": "AWS_DYNAMODB_STREAMS_RECORDS_DELAY",
+            "category": "issue"
+        },
+        {
+            "service": "E2M",
+            "code": "AWS_E2M_OPERATIONAL_CHANGE",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "E2M",
+            "code": "AWS_E2M_SCHEDULED_MAINTENANCE",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EBSONOUTPOSTS",
+            "code": "AWS_EBSONOUTPOSTS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EBSONOUTPOSTS",
+            "code": "AWS_EBSONOUTPOSTS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EBS",
+            "code": "AWS_EBS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EBS",
+            "code": "AWS_EBS_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EBS",
+            "code": "AWS_EBS_DEGRADED_EBS_VOLUME_PERFORMANCE",
+            "category": "issue"
+        },
+        {
+            "service": "EBS",
+            "code": "AWS_EBS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EBS",
+            "code": "AWS_EBS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EBS",
+            "code": "AWS_EBS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EBS",
+            "code": "AWS_EBS_VOLUME_ATTACHMENT_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EBS",
+            "code": "AWS_EBS_VOLUME_LOST",
+            "category": "issue"
+        },
+        {
+            "service": "EBS",
+            "code": "AWS_EBS_VOLUME_MODIFICATION_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "AUTOSCALING",
+            "code": "AWS_EC2_AUTOSCALING_LAUNCH_TEMPLATE_NOT_FOUND",
+            "category": "issue"
+        },
+        {
+            "service": "AUTOSCALING",
+            "code": "AWS_EC2_AUTOSCALING_SECURITY_GROUP_NOT_FOUND",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_BILLING_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_CLASSIC_NETWORK_HEALTH_INTERNET_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_CLASSIC_NETWORK_HEALTH_INTER_AZ_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_CLASSIC_NETWORK_HEALTH_INTRA_AZ_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_DEDICATED_HOST_ACCESS_REVOKED_RETIREMENT_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_DEDICATED_HOST_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_DEDICATED_HOST_NETWORK_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_DEDICATED_HOST_POWER_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_DEDICATED_HOST_RETIREMENT_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_DEDICATED_HOST_UNDER_RESERVATION_REPLACE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_DNS_RESOLUTION_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ELASTIC_GRAPHICS_MAINTENANCE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_HOST_RECOVERY_COMPLETION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_HOST_RECOVERY_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_HOST_RECOVERY_INITIATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_HOST_RECOVERY_PARTIAL_SUCCESS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_HOST_RECOVERY_SUCCESS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_HOST_RECOVERY_UNSUPPORTED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INCREASED_LAUNCH_FAILURES",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_AUTO_RECOVERY_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_AUTO_RECOVERY_NO_ACTION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_AUTO_RECOVERY_SUCCESS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_AVAILABILITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2_INSTANCE_CONNECT",
+            "code": "AWS_EC2_INSTANCE_CONNECT_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "EC2_INSTANCE_CONNECT",
+            "code": "AWS_EC2_INSTANCE_CONNECT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2_INSTANCE_CONNECT",
+            "code": "AWS_EC2_INSTANCE_CONNECT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_CONSTRAINED_BANDWIDTH_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_NETWORK_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_POWER_MAINTENANCE_FAILED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_POWER_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_REBOOT_FLEXIBLE_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_REBOOT_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_RETIREMENT_EXPEDITED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_RETIREMENT_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_STOP_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_INSTANCE_TERMINATION_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_LOCAL_ZONE_SERVICELINK_DISCONNECTED",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_NETWORK_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_OCDR_NOTIFICATIONS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_CANCELED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_CANCELLED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_DELAYED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_DEPOSIT_CONFIRMATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_PENDING_CAPACITY_RESERVATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_SCHEDULED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_SCHEDULE_CONFIRMATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_UNDERUTILIZATION_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_UNDERUTILIZATION_NOTIFICATION_SUMMARY",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_ODCR_UPCOMING_DEPOSIT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_PERSISTENT_INSTANCE_POWER_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_PERSISTENT_INSTANCE_RETIREMENT_EXPEDITED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_PERSISTENT_INSTANCE_RETIREMENT_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_POWER_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_RI_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_RI_MARKETPLACE_BANK_ACCOUNT_UPDATE_REQUIRED",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_RUNINSTANCES_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2_SERIAL_CONSOLE",
+            "code": "AWS_EC2_SERIAL_CONSOLE_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "EC2_SERIAL_CONSOLE",
+            "code": "AWS_EC2_SERIAL_CONSOLE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2_SERIAL_CONSOLE",
+            "code": "AWS_EC2_SERIAL_CONSOLE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_SIMPLIFIED_AUTO_RECOVERY_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_SIMPLIFIED_AUTO_RECOVERY_SUCCESS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_SPOT_API_UNAVAILABILITY",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_VPC_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_VPC_NETWORK_HEALTH_INTERNET_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_VPC_NETWORK_HEALTH_INTER_AZ_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EC2",
+            "code": "AWS_EC2_VPC_NETWORK_HEALTH_INTRA_AZ_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ECR",
+            "code": "AWS_ECR_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ECR",
+            "code": "AWS_ECR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ECR",
+            "code": "AWS_ECR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ECR_PUBLIC",
+            "code": "AWS_ECR_PUBLIC_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ECR_PUBLIC",
+            "code": "AWS_ECR_PUBLIC_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ECR_PUBLIC",
+            "code": "AWS_ECR_PUBLIC_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ECR_PUBLIC",
+            "code": "AWS_ECR_PUBLIC_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ECR",
+            "code": "AWS_ECR_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ECS",
+            "code": "AWS_ECS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ECS",
+            "code": "AWS_ECS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ECS",
+            "code": "AWS_ECS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ECS",
+            "code": "AWS_ECS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ECS",
+            "code": "AWS_ECS_TASK_LAUNCH_ERRORS",
+            "category": "issue"
+        },
+        {
+            "service": "ECS",
+            "code": "AWS_ECS_TASK_PATCHING_RETIREMENT",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "ECS",
+            "code": "AWS_ECS_TASK_RETIREMENT_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EKS",
+            "code": "AWS_EKS_ANYWHERE_SUBSCRIPTION_EXPIRING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EKS",
+            "code": "AWS_EKS_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EKS",
+            "code": "AWS_EKS_MAINTENANCE_NOTIFICATION",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EKS",
+            "code": "AWS_EKS_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "EKS",
+            "code": "AWS_EKS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EKS",
+            "code": "AWS_EKS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EKS",
+            "code": "AWS_EKS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_AFTER_DEADLINE_IGNORE_MAINTENANCE_WINDOW",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_AFTER_DEADLINE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_BEFORE_AUTO_UPDATE_IGNORE_MAINTENANCE_WINDOW",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_BEFORE_UPDATE_DUE_IGNORE_MAINTENANCE_WINDOW",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_BEFORE_UPDATE_DUE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_ENGINE_UPDATE_AVAILABLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_HOURS_BEFORE_AUTO_UPDATE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_INCREASED_CREATE_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_MAINTENANCE_NOTIFICATION",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_MEMCACHED_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_NETWORK_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_PREVIOUS_GENERATION_NODE_DETECTED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_PREVIOUS_GENERATION_NODE_REPLACEMENT_FAILED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_REDIS_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_UPDATE_AVAILABLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_UPDATE_AVAILABLE_IGNORE_MAINTENANCE_WINDOW",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_UPDATE_COMPLETED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICACHE",
+            "code": "AWS_ELASTICACHE_UPDATE_STATUS_CHANGED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICBEANSTALK",
+            "code": "AWS_ELASTICBEANSTALK_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICBEANSTALK",
+            "code": "AWS_ELASTICBEANSTALK_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICBEANSTALK",
+            "code": "AWS_ELASTICBEANSTALK_INCREASED_PROVISIONING_TIMES",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICBEANSTALK",
+            "code": "AWS_ELASTICBEANSTALK_MANAGED_UPDATE_FAILURES",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICBEANSTALK",
+            "code": "AWS_ELASTICBEANSTALK_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICBEANSTALK",
+            "code": "AWS_ELASTICBEANSTALK_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICBEANSTALK",
+            "code": "AWS_ELASTICBEANSTALK_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICBEANSTALK",
+            "code": "AWS_ELASTICBEANSTALK_WORKFLOW_FAULTS",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICBEANSTALK",
+            "code": "AWS_ELASTICBEANSTALK_WORKFLOW_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICFILESYSTEM",
+            "code": "AWS_ELASTICFILESYSTEM_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICFILESYSTEM",
+            "code": "AWS_ELASTICFILESYSTEM_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICFILESYSTEM",
+            "code": "AWS_ELASTICFILESYSTEM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICFILESYSTEM",
+            "code": "AWS_ELASTICFILESYSTEM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICFILESYSTEM",
+            "code": "AWS_ELASTICFILESYSTEM_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_ENI_LIMIT_REACHED",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_INCREASED_INSTANCE_REGISTRATION_TIMES",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_INCREASED_PROVISIONING_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_INSUFFICIENT_COIP",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_INSUFFICIENT_INSTANCE_CAPACITY",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_INVALID_CERTIFICATE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_NETWORK_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_NODE_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_NO_IPV6_CIDR_BLOCKS_ASSOCIATED_WITH_SUBNET",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_SECURITY_GROUPS_PER_INTERFACE_LIMIT_EXCEEDED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_SECURITY_GROUP_NOT_FOUND",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_STABLE_IP_NEEDS_IP",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICLOADBALANCING",
+            "code": "AWS_ELASTICLOADBALANCING_UNSUPPORTED_CERTIFICATE_TYPE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_BLOCK_PUBLIC_ACCESS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_BLOCK_PUBLIC_ACCESS_SECURITY_VIOLATION",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_CLUSTER_LAUNCH_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_CLUSTER_LAUNCH_FAILURES",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_INCREASED_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_NOTICE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICMAPREDUCE",
+            "code": "AWS_ELASTICMAPREDUCE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELASTICTRANSCODER",
+            "code": "AWS_ELASTICTRANSCODER_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICTRANSCODER",
+            "code": "AWS_ELASTICTRANSCODER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ELASTICTRANSCODER",
+            "code": "AWS_ELASTICTRANSCODER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ELEMENTAL",
+            "code": "AWS_ELEMENTAL_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EMR_SERVERLESS",
+            "code": "AWS_EMR_SERVERLESS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EMR_SERVERLESS",
+            "code": "AWS_EMR_SERVERLESS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ENTITYRESOLUTION",
+            "code": "AWS_ENTITYRESOLUTION_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ENTITYRESOLUTION",
+            "code": "AWS_ENTITYRESOLUTION_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "ENTITYRESOLUTION",
+            "code": "AWS_ENTITYRESOLUTION_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ENTITYRESOLUTION",
+            "code": "AWS_ENTITYRESOLUTION_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_CARBON_ALL_KIBANA_OOS_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_CARBON_HIGH_P95_ELB_LATENCY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_DOMAIN_ISOLATION_COMPLETED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_DOMAIN_UNAVAILABLE",
+            "category": "issue"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_HIGH_DOMAIN_UNAVAILABILITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_NOTICE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_OSIS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_SCALE_UP_REQUIRED",
+            "category": "issue"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_SERVICE_SOFTWARE_UPDATE_AVAILABLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_SERVICE_SOFTWARE_UPDATE_REQUIRED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_SERVICE_SOFTWARE_UPDATE_RESCHEDULED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ES",
+            "code": "AWS_ES_SERVICE_SOFTWARE_UPDATE_SCHEDULED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EVENTS",
+            "code": "AWS_EVENTS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EVENTS",
+            "code": "AWS_EVENTS_INCREASED_API_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "EVENTS",
+            "code": "AWS_EVENTS_INCREASED_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "EVENTS",
+            "code": "AWS_EVENTS_INCREASED_EVENT_DELIVERY_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "EVENTS",
+            "code": "AWS_EVENTS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EVENTS",
+            "code": "AWS_EVENTS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EVENTS_SCHEDULER",
+            "code": "AWS_EVENTS_SCHEDULER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EVENTS_SCHEDULER",
+            "code": "AWS_EVENTS_SCHEDULER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EVENTS",
+            "code": "AWS_EVENTS_SCHEMA_INCREASED_API_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "EVENTS",
+            "code": "AWS_EVENTS_SCHEMA_INCREASED_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "EVENTS",
+            "code": "AWS_EVENTS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "EVIDENTLY",
+            "code": "AWS_EVIDENTLY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "EVIDENTLY",
+            "code": "AWS_EVIDENTLY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "FARGATE",
+            "code": "AWS_FARGATE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FARGATE",
+            "code": "AWS_FARGATE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "FARGATE",
+            "code": "AWS_FARGATE_TASK_LAUNCH_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "FARGATE",
+            "code": "AWS_FARGATE_TASK_PLACEMENT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FINSPACE",
+            "code": "AWS_FINSPACE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FIREHOSE",
+            "code": "AWS_FIREHOSE_HTTP_ENDPOINT_RECORD_DELIVERY_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "FIREHOSE",
+            "code": "AWS_FIREHOSE_INCREASED_REDSHIFT_DELIVERY_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "FIREHOSE",
+            "code": "AWS_FIREHOSE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FIREHOSE",
+            "code": "AWS_FIREHOSE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "FIREHOSE",
+            "code": "AWS_FIREHOSE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "FIS",
+            "code": "AWS_FIS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FMS",
+            "code": "AWS_FMS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FMS",
+            "code": "AWS_FMS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "FMS",
+            "code": "AWS_FMS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "FORECAST",
+            "code": "AWS_FORECAST_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FORECAST",
+            "code": "AWS_FORECAST_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "FRAUDDETECTOR",
+            "code": "AWS_FRAUDDETECTOR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FREERTOS",
+            "code": "AWS_FREERTOS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FREERTOS",
+            "code": "AWS_FREERTOS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "FSX",
+            "code": "AWS_FSX_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "FSX",
+            "code": "AWS_FSX_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "FSX",
+            "code": "AWS_FSX_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "FSX",
+            "code": "AWS_FSX_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GAMELIFT",
+            "code": "AWS_GAMELIFT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GAMELIFT",
+            "code": "AWS_GAMELIFT_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GAMELIFT",
+            "code": "AWS_GAMELIFT_FLEET_CREATE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GAMELIFT",
+            "code": "AWS_GAMELIFT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GAMELIFT",
+            "code": "AWS_GAMELIFT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GAMELIFT",
+            "code": "AWS_GAMELIFT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GAMESPARKS",
+            "code": "AWS_GAMESPARKS_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "GAMESPARKS",
+            "code": "AWS_GAMESPARKS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GAMESPARKS",
+            "code": "AWS_GAMESPARKS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GEO",
+            "code": "AWS_GEO_METADATA_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GEO",
+            "code": "AWS_GEO_METADATA_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "GEO",
+            "code": "AWS_GEO_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GEO",
+            "code": "AWS_GEO_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GLACIER",
+            "code": "AWS_GLACIER_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GLACIER",
+            "code": "AWS_GLACIER_INCREASED_POST_RESTORE_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GLACIER",
+            "code": "AWS_GLACIER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GLACIER",
+            "code": "AWS_GLACIER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GLACIER",
+            "code": "AWS_GLACIER_RESTORATION_THROUGHPUT_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "GLOBALACCELERATOR",
+            "code": "AWS_GLOBALACCELERATOR_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GLOBALACCELERATOR",
+            "code": "AWS_GLOBALACCELERATOR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GLOBALACCELERATOR",
+            "code": "AWS_GLOBALACCELERATOR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GLUE",
+            "code": "AWS_GLUE_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GLUE",
+            "code": "AWS_GLUE_MITIGATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GLUE",
+            "code": "AWS_GLUE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GLUE",
+            "code": "AWS_GLUE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GLUE",
+            "code": "AWS_GLUE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GRAFANA",
+            "code": "AWS_GRAFANA_MAINTENANCE_SCHEDULE",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "GRAFANA",
+            "code": "AWS_GRAFANA_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "GRAFANA",
+            "code": "AWS_GRAFANA_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GREENGRASS",
+            "code": "AWS_GREENGRASS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GREENGRASS",
+            "code": "AWS_GREENGRASS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GREENGRASS",
+            "code": "AWS_GREENGRASS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GROUNDSTATION",
+            "code": "AWS_GROUNDSTATION_CONTACT_CANCELED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GROUNDSTATION",
+            "code": "AWS_GROUNDSTATION_DATAFLOW_ENDPOINT_GROUPS_UNHEALTHY",
+            "category": "issue"
+        },
+        {
+            "service": "GROUNDSTATION",
+            "code": "AWS_GROUNDSTATION_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GROUNDSTATION",
+            "code": "AWS_GROUNDSTATION_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GUARDDUTY",
+            "code": "AWS_GUARDDUTY_FINDING_TYPE_UPDATE",
+            "category": "issue"
+        },
+        {
+            "service": "GUARDDUTY",
+            "code": "AWS_GUARDDUTY_MALWARE_PROTECTION_ENABLEMENT_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GUARDDUTY",
+            "code": "AWS_GUARDDUTY_MEMBER_INVITATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GUARDDUTY",
+            "code": "AWS_GUARDDUTY_MEMBER_LIMIT_REACHED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GUARDDUTY",
+            "code": "AWS_GUARDDUTY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "GUARDDUTY",
+            "code": "AWS_GUARDDUTY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GUARDDUTY",
+            "code": "AWS_GUARDDUTY_PUBLISHING_STOPPED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GUARDDUTY",
+            "code": "AWS_GUARDDUTY_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "GUARDDUTY",
+            "code": "AWS_GUARDDUTY_SERVICE_ENABLEMENT_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "HEALTHIMAGING",
+            "code": "AWS_HEALTHIMAGING_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "HEALTHIMAGING",
+            "code": "AWS_HEALTHIMAGING_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "HEALTHIMAGING",
+            "code": "AWS_HEALTHIMAGING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "HEALTHIMAGING",
+            "code": "AWS_HEALTHIMAGING_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "HEALTHLAKE",
+            "code": "AWS_HEALTHLAKE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "HEALTHLAKE",
+            "code": "AWS_HEALTHLAKE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "HEALTH",
+            "code": "AWS_HEALTH_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "HEALTH",
+            "code": "AWS_HEALTH_INCIDENT_DETECTION_RESPONSE_CUSTOMER_INCIDENT",
+            "category": "issue"
+        },
+        {
+            "service": "HEALTH",
+            "code": "AWS_HEALTH_INCIDENT_DETECTION_RESPONSE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "HEALTH",
+            "code": "AWS_HEALTH_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "HEALTH",
+            "code": "AWS_HEALTH_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "HEALTH",
+            "code": "AWS_HEALTH_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "HONEYCODE",
+            "code": "AWS_HONEYCODE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "HONEYCODE",
+            "code": "AWS_HONEYCODE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IAMIDENTITYCENTER",
+            "code": "AWS_IAMIDENTITYCENTER_ACCESS_PORTAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IAMIDENTITYCENTER",
+            "code": "AWS_IAMIDENTITYCENTER_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IAMIDENTITYCENTER",
+            "code": "AWS_IAMIDENTITYCENTER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IAMIDENTITYCENTER",
+            "code": "AWS_IAMIDENTITYCENTER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IAMIDENTITYCENTER",
+            "code": "AWS_IAMIDENTITYCENTER_SCIM_BEARER_TOKEN_EXPIRY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IAMROLESANYWHERE",
+            "code": "AWS_IAMROLESANYWHERE_CA_CERT_EXPIRY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IAMROLESANYWHERE",
+            "code": "AWS_IAMROLESANYWHERE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IAMROLESANYWHERE",
+            "code": "AWS_IAMROLESANYWHERE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IAM",
+            "code": "AWS_IAM_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IAM",
+            "code": "AWS_IAM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IAM",
+            "code": "AWS_IAM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IAM",
+            "code": "AWS_IAM_SAML-BASED_FEDERATED_SIGN-IN_ERRORS",
+            "category": "issue"
+        },
+        {
+            "service": "IAM",
+            "code": "AWS_IAM_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IMAGEBUILDER",
+            "code": "AWS_IMAGEBUILDER_COMPONENT_DEPRECATION_EOL",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IMAGEBUILDER",
+            "code": "AWS_IMAGEBUILDER_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IMAGEBUILDER",
+            "code": "AWS_IMAGEBUILDER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IMAGEBUILDER",
+            "code": "AWS_IMAGEBUILDER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IMPORTEXPORT",
+            "code": "AWS_IMPORTEXPORT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IMPORTEXPORT",
+            "code": "AWS_IMPORTEXPORT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IMPORTEXPORT",
+            "code": "AWS_IMPORTEXPORT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "INFRASTRUCTUREPERFORMANCE",
+            "code": "AWS_INFRASTRUCTUREPERFORMANCE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "INFRASTRUCTUREPERFORMANCE",
+            "code": "AWS_INFRASTRUCTUREPERFORMANCE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "INSPECTOR2",
+            "code": "AWS_INSPECTOR2_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "INSPECTOR2",
+            "code": "AWS_INSPECTOR2_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "INSPECTOR",
+            "code": "AWS_INSPECTOR_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "INSPECTOR",
+            "code": "AWS_INSPECTOR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "INSPECTOR",
+            "code": "AWS_INSPECTOR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "INSPECTOR",
+            "code": "AWS_INSPECTOR_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "INSPECTOR",
+            "code": "AWS_INSPECTOR_SERVICE_ENABLEMENT_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "INTERNETCONNECTIVITY",
+            "code": "AWS_INTERNETCONNECTIVITY_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "INTERNETCONNECTIVITY",
+            "code": "AWS_INTERNETCONNECTIVITY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "INTERNETCONNECTIVITY",
+            "code": "AWS_INTERNETCONNECTIVITY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "INTERNETMONITOR",
+            "code": "AWS_INTERNETMONITOR_CONNECTIVITY_CLOUDFRONT_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "INTERNETMONITOR",
+            "code": "AWS_INTERNETMONITOR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "INTERNETMONITOR",
+            "code": "AWS_INTERNETMONITOR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "INTERREGIONVPCPEERING",
+            "code": "AWS_INTERREGIONVPCPEERING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "INTERREGIONVPCPEERING",
+            "code": "AWS_INTERREGIONVPCPEERING_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT1CLICK",
+            "code": "AWS_IOT1CLICK_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT1CLICK",
+            "code": "AWS_IOT1CLICK_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOTROBORUNNER",
+            "code": "AWS_IOTROBORUNNER_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOTROBORUNNER",
+            "code": "AWS_IOTROBORUNNER_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "IOTROBORUNNER",
+            "code": "AWS_IOTROBORUNNER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOTROBORUNNER",
+            "code": "AWS_IOTROBORUNNER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOTTWINMAKER",
+            "code": "AWS_IOTTWINMAKER_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOTTWINMAKER",
+            "code": "AWS_IOTTWINMAKER_CONSOLE_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "IOTTWINMAKER",
+            "code": "AWS_IOTTWINMAKER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOTTWINMAKER",
+            "code": "AWS_IOTTWINMAKER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_ANALYTICS",
+            "code": "AWS_IOT_ANALYTICS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_ANALYTICS",
+            "code": "AWS_IOT_ANALYTICS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT",
+            "code": "AWS_IOT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_CORE",
+            "code": "AWS_IOT_CORE_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "IOT_CORE",
+            "code": "AWS_IOT_CORE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_CORE",
+            "code": "AWS_IOT_CORE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_CORE",
+            "code": "AWS_IOT_CORE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT",
+            "code": "AWS_IOT_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_DEVICE_ADVISOR",
+            "code": "AWS_IOT_DEVICE_ADVISOR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_DEVICE_ADVISOR",
+            "code": "AWS_IOT_DEVICE_ADVISOR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_DEVICE_DEFENDER",
+            "code": "AWS_IOT_DEVICE_DEFENDER_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_DEVICE_DEFENDER",
+            "code": "AWS_IOT_DEVICE_DEFENDER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_DEVICE_DEFENDER",
+            "code": "AWS_IOT_DEVICE_DEFENDER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_DEVICE_MANAGEMENT",
+            "code": "AWS_IOT_DEVICE_MANAGEMENT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_DEVICE_MANAGEMENT",
+            "code": "AWS_IOT_DEVICE_MANAGEMENT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_DEVICE_MANAGEMENT",
+            "code": "AWS_IOT_DEVICE_MANAGEMENT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_EVENTS",
+            "code": "AWS_IOT_EVENTS_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_EVENTS",
+            "code": "AWS_IOT_EVENTS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_EVENTS",
+            "code": "AWS_IOT_EVENTS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_EVENTS",
+            "code": "AWS_IOT_EVENTS_PROCESSING_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_EVENTS",
+            "code": "AWS_IOT_EVENTS_PROCESSING_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_FLEETWISE",
+            "code": "AWS_IOT_FLEETWISE_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "IOT_FLEETWISE",
+            "code": "AWS_IOT_FLEETWISE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_FLEETWISE",
+            "code": "AWS_IOT_FLEETWISE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_FLEETWISE",
+            "code": "AWS_IOT_FLEETWISE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT",
+            "code": "AWS_IOT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT",
+            "code": "AWS_IOT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT",
+            "code": "AWS_IOT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_SITEWISE",
+            "code": "AWS_IOT_SITEWISE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_SITEWISE",
+            "code": "AWS_IOT_SITEWISE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IOT_WIRELESS",
+            "code": "AWS_IOT_WIRELESS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IOT_WIRELESS",
+            "code": "AWS_IOT_WIRELESS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IPAM",
+            "code": "AWS_IPAM_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IPAM",
+            "code": "AWS_IPAM_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "IPAM",
+            "code": "AWS_IPAM_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "IPAM",
+            "code": "AWS_IPAM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IPAM",
+            "code": "AWS_IPAM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IQ",
+            "code": "AWS_IQ_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IQ",
+            "code": "AWS_IQ_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IQ",
+            "code": "AWS_IQ_UNREAD_MESSAGE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "IVS",
+            "code": "AWS_IVS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "IVS",
+            "code": "AWS_IVS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KAFKA",
+            "code": "AWS_KAFKA_CERTIFICATE_UPDATE_EVENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KAFKA",
+            "code": "AWS_KAFKA_CONNECT_SYSTEM_MAINTENANCE",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "KAFKA",
+            "code": "AWS_KAFKA_DATA_DISK_USAGE_60",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KAFKA",
+            "code": "AWS_KAFKA_DATA_DISK_USAGE_60_PERCENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KAFKA",
+            "code": "AWS_KAFKA_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "KAFKA",
+            "code": "AWS_KAFKA_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KAFKA",
+            "code": "AWS_KAFKA_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KAFKA",
+            "code": "AWS_KAFKA_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KAFKA",
+            "code": "AWS_KAFKA_SECURITY_PATCHING_EVENT",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "KENDRA",
+            "code": "AWS_KENDRA_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KENDRA",
+            "code": "AWS_KENDRA_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KENDRA_RANKING",
+            "code": "AWS_KENDRA_RANKING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KENDRA_RANKING",
+            "code": "AWS_KENDRA_RANKING_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KINESISANALYTICS",
+            "code": "AWS_KINESISANALYTICS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KINESISANALYTICS",
+            "code": "AWS_KINESISANALYTICS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KINESISANALYTICS",
+            "code": "AWS_KINESISANALYTICS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KINESIS",
+            "code": "AWS_KINESIS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KINESIS",
+            "code": "AWS_KINESIS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KINESIS",
+            "code": "AWS_KINESIS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KINESIS",
+            "code": "AWS_KINESIS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KINESIS_VIDEO",
+            "code": "AWS_KINESIS_VIDEO_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KINESIS_VIDEO",
+            "code": "AWS_KINESIS_VIDEO_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KINESIS_VIDEO",
+            "code": "AWS_KINESIS_VIDEO_STREAMS_API_FAULT",
+            "category": "issue"
+        },
+        {
+            "service": "KINESIS_VIDEO",
+            "code": "AWS_KINESIS_VIDEO_STREAMS_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "KINESIS_VIDEO",
+            "code": "AWS_KINESIS_VIDEO_WEBRTC_API_FAULT",
+            "category": "issue"
+        },
+        {
+            "service": "KINESIS_VIDEO",
+            "code": "AWS_KINESIS_VIDEO_WEBRTC_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "KMS",
+            "code": "AWS_KMS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KMS",
+            "code": "AWS_KMS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "KMS",
+            "code": "AWS_KMS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "KMS",
+            "code": "AWS_KMS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LAKEFORMATION",
+            "code": "AWS_LAKEFORMATION_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LAKEFORMATION",
+            "code": "AWS_LAKEFORMATION_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LAKEFORMATION",
+            "code": "AWS_LAKEFORMATION_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LAMBDA",
+            "code": "AWS_LAMBDA_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LAMBDA",
+            "code": "AWS_LAMBDA_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LAMBDA",
+            "code": "AWS_LAMBDA_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LAMBDA",
+            "code": "AWS_LAMBDA_IAM_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LAMBDA",
+            "code": "AWS_LAMBDA_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LAMBDA",
+            "code": "AWS_LAMBDA_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LAMBDA",
+            "code": "AWS_LAMBDA_RUNAWAY_DETECTION_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LAMBDA",
+            "code": "AWS_LAMBDA_RUNAWAY_TERMINATION_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LAMBDA",
+            "code": "AWS_LAMBDA_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LAUNCHWIZARD",
+            "code": "AWS_LAUNCHWIZARD_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LAUNCHWIZARD",
+            "code": "AWS_LAUNCHWIZARD_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LAUNCHWIZARD",
+            "code": "AWS_LAUNCHWIZARD_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LEX",
+            "code": "AWS_LEX_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LEX",
+            "code": "AWS_LEX_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LICENSE_MANAGER",
+            "code": "AWS_LICENSE_MANAGER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LICENSE_MANAGER",
+            "code": "AWS_LICENSE_MANAGER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LIGHTSAIL",
+            "code": "AWS_LIGHTSAIL_CERTIFICATE_EXPIRATION_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LIGHTSAIL",
+            "code": "AWS_LIGHTSAIL_DISK_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LIGHTSAIL",
+            "code": "AWS_LIGHTSAIL_INSTANCE_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "LIGHTSAIL",
+            "code": "AWS_LIGHTSAIL_INSTANCE_RETIREMENT_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "LIGHTSAIL",
+            "code": "AWS_LIGHTSAIL_INSTANCE_ROOT_VOLUME_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LIGHTSAIL",
+            "code": "AWS_LIGHTSAIL_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LIGHTSAIL",
+            "code": "AWS_LIGHTSAIL_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LIGHTSAIL",
+            "code": "AWS_LIGHTSAIL_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LOCATION",
+            "code": "AWS_LOCATION_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LOOKOUTMETRICS",
+            "code": "AWS_LOOKOUTMETRICS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LOOKOUTMETRICS",
+            "code": "AWS_LOOKOUTMETRICS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LOOKOUTVISION",
+            "code": "AWS_LOOKOUTVISION_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "LOOKOUTVISION",
+            "code": "AWS_LOOKOUTVISION_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "LOOKOUT_EQUIPMENT",
+            "code": "AWS_LOOKOUT_EQUIPMENT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MACHINELEARNING",
+            "code": "AWS_MACHINELEARNING_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MACHINELEARNING",
+            "code": "AWS_MACHINELEARNING_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MACHINELEARNING",
+            "code": "AWS_MACHINELEARNING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MACHINELEARNING",
+            "code": "AWS_MACHINELEARNING_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_MEMBER_INVITATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_PAUSED_JOB_CANCELLED_EVENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_PAUSED_JOB_EXPIRATION_EVENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_PAUSED_JOB_RUN_CANCELLED_EVENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_PAUSED_JOB_RUN_EXPIRATION_EVENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_QUOTA_REACHED_AUTOMATED_SENSITIVE_DATA_DISCOVERY_FREE_TRIAL",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MACIE",
+            "code": "AWS_MACIE_SERVICE_ENABLEMENT_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "MAINFRAME_MODERNIZATION",
+            "code": "AWS_MAINFRAME_MODERNIZATION_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MAINFRAME_MODERNIZATION",
+            "code": "AWS_MAINFRAME_MODERNIZATION_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MANAGEDBLOCKCHAIN",
+            "code": "AWS_MANAGEDBLOCKCHAIN_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MANAGEDBLOCKCHAIN",
+            "code": "AWS_MANAGEDBLOCKCHAIN_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MANAGEDBLOCKCHAIN",
+            "code": "AWS_MANAGEDBLOCKCHAIN_QUERY_API_DATA_ERROR",
+            "category": "issue"
+        },
+        {
+            "service": "MANAGEDBLOCKCHAIN",
+            "code": "AWS_MANAGEDBLOCKCHAIN_QUERY_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MANAGEDBLOCKCHAIN",
+            "code": "AWS_MANAGEDBLOCKCHAIN_QUERY_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "MANAGEMENTCONSOLE",
+            "code": "AWS_MANAGEMENTCONSOLE_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MANAGEMENTCONSOLE",
+            "code": "AWS_MANAGEMENTCONSOLE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MANAGEMENTCONSOLE",
+            "code": "AWS_MANAGEMENTCONSOLE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_CONTACT_SELLER",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_CONTACT_SELLER_OPPORTUNITY_EXPIRED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_NEW_VERSION_NO_VERSION_RESTRICTION_ONGOING_SUPPORT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_NEW_VERSION_OPT_IMPROVEMENTS_VERSION_RESTRICTION_NO_UPGRADE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_NEW_VERSION_OPT_IMPROVEMENTS_VERSION_RESTRICTION_ONGOING_SUPPORT_NO_UPGRADE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_REC_SCANS_VULNERABILITY_NOTIFICATION",
+            "category": "issue"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_REC_SCANS_VULNERABILITY_NOTIFICATION_REMINDER",
+            "category": "issue"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_RI_DISBURSEMENT_FAILURE_NO_BANK_ACCOUNT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_SAAS_CONTRACT_PRODUCT_SUNSET_END_OF_SUPPORT_REPLACEMENT_PRODUCT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_SAAS_CONTRACT_PRODUCT_SUNSET_ONGOING_SUPPORT_REPLACEMENT_PRODUCT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_SAAS_EULA_UPDATE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MARKETPLACE",
+            "code": "AWS_MARKETPLACE_SERVER_PRODUCTS_TASKS_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIACONNECT",
+            "code": "AWS_MEDIACONNECT_FLOW_MAINTENANCE_NOTIFICATION",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "MEDIACONNECT",
+            "code": "AWS_MEDIACONNECT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MEDIACONNECT",
+            "code": "AWS_MEDIACONNECT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIACONVERT",
+            "code": "AWS_MEDIACONVERT_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIACONVERT",
+            "code": "AWS_MEDIACONVERT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MEDIACONVERT",
+            "code": "AWS_MEDIACONVERT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIACONVERT",
+            "code": "AWS_MEDIACONVERT_RTS_AUTO_RENEW",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIACONVERT",
+            "code": "AWS_MEDIACONVERT_RTS_EXPIRED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIACONVERT",
+            "code": "AWS_MEDIACONVERT_RTS_EXPIRING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIACONVERT",
+            "code": "AWS_MEDIACONVERT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIALIVE",
+            "code": "AWS_MEDIALIVE_MAINTENANCE_EVENT_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIALIVE",
+            "code": "AWS_MEDIALIVE_MAINTENANCE_FIRST_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIALIVE",
+            "code": "AWS_MEDIALIVE_MAINTENANCE_NOTIFICATION",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "MEDIALIVE",
+            "code": "AWS_MEDIALIVE_MAINTENANCE_RESCHEDULE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIALIVE",
+            "code": "AWS_MEDIALIVE_MANUAL_MAINTENANCE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIALIVE",
+            "code": "AWS_MEDIALIVE_MANUAL_MAINTENANCE_PAST_DUE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIALIVE",
+            "code": "AWS_MEDIALIVE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MEDIALIVE",
+            "code": "AWS_MEDIALIVE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIAPACKAGE",
+            "code": "AWS_MEDIAPACKAGE_EGRESS_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MEDIAPACKAGE",
+            "code": "AWS_MEDIAPACKAGE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MEDIAPACKAGE",
+            "code": "AWS_MEDIAPACKAGE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIAPACKAGE",
+            "code": "AWS_MEDIAPACKAGE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIASTORE",
+            "code": "AWS_MEDIASTORE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MEDIASTORE",
+            "code": "AWS_MEDIASTORE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEDIATAILOR",
+            "code": "AWS_MEDIATAILOR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MEDIATAILOR",
+            "code": "AWS_MEDIATAILOR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEMORYDB",
+            "code": "AWS_MEMORYDB_AFTER_DEADLINE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEMORYDB",
+            "code": "AWS_MEMORYDB_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MEMORYDB",
+            "code": "AWS_MEMORYDB_BEFORE_AUTO_UPDATE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEMORYDB",
+            "code": "AWS_MEMORYDB_BEFORE_UPDATE_DUE_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEMORYDB",
+            "code": "AWS_MEMORYDB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MEMORYDB",
+            "code": "AWS_MEMORYDB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEMORYDB",
+            "code": "AWS_MEMORYDB_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEMORYDB",
+            "code": "AWS_MEMORYDB_UPDATE_AVAILABLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MEMORYDB",
+            "code": "AWS_MEMORYDB_UPDATE_COMPLETED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MGH",
+            "code": "AWS_MGH_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MGH",
+            "code": "AWS_MGH_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MGN",
+            "code": "AWS_MGN_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "MGN",
+            "code": "AWS_MGN_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MGN",
+            "code": "AWS_MGN_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MIGRATIONHUBORCHESTRATOR",
+            "code": "AWS_MIGRATIONHUBORCHESTRATOR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MIGRATIONHUBORCHESTRATOR",
+            "code": "AWS_MIGRATIONHUBORCHESTRATOR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MIGRATIONHUBSTRATEGY",
+            "code": "AWS_MIGRATIONHUBSTRATEGY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MIGRATIONHUBSTRATEGY",
+            "code": "AWS_MIGRATIONHUBSTRATEGY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MOBILEANALYTICS",
+            "code": "AWS_MOBILEANALYTICS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILEANALYTICS",
+            "code": "AWS_MOBILEANALYTICS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILEANALYTICS",
+            "code": "AWS_MOBILEANALYTICS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MOBILEHUB",
+            "code": "AWS_MOBILEHUB_ACCOUNT_NOT_SETUP",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILEHUB",
+            "code": "AWS_MOBILEHUB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILEHUB",
+            "code": "AWS_MOBILEHUB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_MOBILETARGETING_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_MOBILETARGETING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_MOBILETARGETING_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_MOBILETARGETING_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MONITRON",
+            "code": "AWS_MONITRON_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MONITRON",
+            "code": "AWS_MONITRON_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MQ",
+            "code": "AWS_MQ_BILLING_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MQ",
+            "code": "AWS_MQ_BROKER_CRITICAL_ACTION_REQUIRED",
+            "category": "issue"
+        },
+        {
+            "service": "MQ",
+            "code": "AWS_MQ_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MQ",
+            "code": "AWS_MQ_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MQ",
+            "code": "AWS_MQ_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MULTIPLE_SERVICES",
+            "code": "AWS_MULTIPLE_SERVICES_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "NATGATEWAY",
+            "code": "AWS_NATGATEWAY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "NATGATEWAY",
+            "code": "AWS_NATGATEWAY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "NEPTUNE",
+            "code": "AWS_NEPTUNE_HARDWARE_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "NEPTUNE",
+            "code": "AWS_NEPTUNE_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "NEPTUNE",
+            "code": "AWS_NEPTUNE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "NEPTUNE",
+            "code": "AWS_NEPTUNE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "NEPTUNE",
+            "code": "AWS_NEPTUNE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "NETWORKFIREWALL",
+            "code": "AWS_NETWORKFIREWALL_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "NETWORKFIREWALL",
+            "code": "AWS_NETWORKFIREWALL_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "NETWORK_ACCESS_ANALYZER",
+            "code": "AWS_NETWORK_ACCESS_ANALYZER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "NETWORK_ACCESS_ANALYZER",
+            "code": "AWS_NETWORK_ACCESS_ANALYZER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "NIMBLE",
+            "code": "AWS_NIMBLE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "NIMBLE",
+            "code": "AWS_NIMBLE_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "NOTIFICATIONS",
+            "code": "AWS_NOTIFICATIONS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "NOTIFICATIONS",
+            "code": "AWS_NOTIFICATIONS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "OMICS",
+            "code": "AWS_OMICS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "OMICS",
+            "code": "AWS_OMICS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "OPSWORKS-CM",
+            "code": "AWS_OPSWORKS-CM_MAINTENANCE_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "OPSWORKS-CM",
+            "code": "AWS_OPSWORKS-CM_SERVER_CONNECTION_LOST",
+            "category": "issue"
+        },
+        {
+            "service": "OPSWORKS",
+            "code": "AWS_OPSWORKS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "OPSWORKS_CHEF",
+            "code": "AWS_OPSWORKS_CHEF_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "OPSWORKS_CHEF",
+            "code": "AWS_OPSWORKS_CHEF_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "OPSWORKS",
+            "code": "AWS_OPSWORKS_INSTANCE_LAUNCH_COMMAND_EXECUTION_DELAYS",
+            "category": "issue"
+        },
+        {
+            "service": "OPSWORKS",
+            "code": "AWS_OPSWORKS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "OPSWORKS",
+            "code": "AWS_OPSWORKS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "OPSWORKS_PUPPET",
+            "code": "AWS_OPSWORKS_PUPPET_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "OPSWORKS_PUPPET",
+            "code": "AWS_OPSWORKS_PUPPET_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "OPSWORKS",
+            "code": "AWS_OPSWORKS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ORGANIZATIONS",
+            "code": "AWS_ORGANIZATIONS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ORGANIZATIONS",
+            "code": "AWS_ORGANIZATIONS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ORGANIZATIONS",
+            "code": "AWS_ORGANIZATIONS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "OUTPOSTS",
+            "code": "AWS_OUTPOSTS_HARDWARE_REPLACEMENT",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "OUTPOSTS",
+            "code": "AWS_OUTPOSTS_IMPACTING_UPDATE",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "OUTPOSTS",
+            "code": "AWS_OUTPOSTS_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "OUTPOSTS",
+            "code": "AWS_OUTPOSTS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "OUTPOSTS",
+            "code": "AWS_OUTPOSTS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "OUTPOSTS",
+            "code": "AWS_OUTPOSTS_SERVICE_LINK_DOWN",
+            "category": "issue"
+        },
+        {
+            "service": "PANORAMA",
+            "code": "AWS_PANORAMA_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "PANORAMA",
+            "code": "AWS_PANORAMA_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "PAYMENTCRYPTOGRAPHY",
+            "code": "AWS_PAYMENTCRYPTOGRAPHY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "PAYMENTCRYPTOGRAPHY",
+            "code": "AWS_PAYMENTCRYPTOGRAPHY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "PERSONALIZE",
+            "code": "AWS_PERSONALIZE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "PERSONALIZE",
+            "code": "AWS_PERSONALIZE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_ANALYTICS_ERRORS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_DATA_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_ENGAGEMENT_ERRORS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_ENGAGEMENT_IMPAIRED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "PINPOINT",
+            "code": "AWS_PINPOINT_EVENT_STREAM_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "PINPOINT",
+            "code": "AWS_PINPOINT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "MOBILETARGETING",
+            "code": "AWS_PINPOINT_SERVICE_ISSUE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "POLLY",
+            "code": "AWS_POLLY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "POLLY",
+            "code": "AWS_POLLY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "PRICING",
+            "code": "AWS_PRICING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "PRICING",
+            "code": "AWS_PRICING_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "PRIVATE_5G",
+            "code": "AWS_PRIVATE_5G_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "PRIVATE_5G",
+            "code": "AWS_PRIVATE_5G_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "PRIVATE_5G",
+            "code": "AWS_PRIVATE_5G_NETWORK_HEALTH_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "PRIVATE_5G",
+            "code": "AWS_PRIVATE_5G_OPERATIONAL_INVESTIGATION",
+            "category": "issue"
+        },
+        {
+            "service": "PRIVATE_5G",
+            "code": "AWS_PRIVATE_5G_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "PRIVATE_5G",
+            "code": "AWS_PRIVATE_5G_OPERATIONAL_NOTIFICATION",
+            "category": "issue"
+        },
+        {
+            "service": "PROTON",
+            "code": "AWS_PROTON_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "QLDB",
+            "code": "AWS_QLDB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "QLDB",
+            "code": "AWS_QLDB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "QUICKSIGHT",
+            "code": "AWS_QUICKSIGHT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "QUICKSIGHT",
+            "code": "AWS_QUICKSIGHT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RAM",
+            "code": "AWS_RAM_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RAM",
+            "code": "AWS_RAM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RAM",
+            "code": "AWS_RAM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RAM",
+            "code": "AWS_RAM_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_AURORA_HARDWARE_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_AURORA_MYSQL_INCOMPATIBLE_PARAMETERS",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_AURORA_MYSQL_INCOMPATIBLE_PARAMETER_CHARSET_COLLATION",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_AURORA_MYSQL_INSTANCE_CRASHING_REPEATEDLY",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_AURORA_MYSQL_INSTANCE_HEAVY_WORKLOAD",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_AURORA_MYSQL_PERFORMANCE_SCHEMA_ENABLED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_AURORA_MYSQL_T2_CPU_CREDITS",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_AURORA_MYSQL_T2_CPU_CREDIT_EXHAUSTION",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_DATABASE_ACTIVITY_STREAMS_KMS_NOT_ACCESSIBLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_DESCRIBEPENDINGMAINTENANCEACTIONS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_EXPORT_TASK_FAILED",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_HARDWARE_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_INCREASED_CREATE_SCALING_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_INSTANCE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_LOWER_CASE_TABLE_NAMES_IS_NOT_SUPPORTED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_MYSQL_DATABASE_CRASHING_REPEATEDLY",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_POINT_IN_TIME_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_PUBLIC_SNAPSHOT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_STORAGE_FAILURE_DB_CORRUPTION",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_STORAGE_FAILURE_MAZ",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_STORAGE_FAILURE_READREPLICA",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_STORAGE_FAILURE_SAZ",
+            "category": "issue"
+        },
+        {
+            "service": "RDS",
+            "code": "AWS_RDS_SYSTEM_UPGRADE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "REACHABILITY_ANALYZER",
+            "code": "AWS_REACHABILITY_ANALYZER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REACHABILITY_ANALYZER",
+            "code": "AWS_REACHABILITY_ANALYZER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "REDSHIFT",
+            "code": "AWS_REDSHIFT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REDSHIFT",
+            "code": "AWS_REDSHIFT_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REDSHIFT",
+            "code": "AWS_REDSHIFT_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "REDSHIFT",
+            "code": "AWS_REDSHIFT_INCREASED_CREATE_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "REDSHIFT",
+            "code": "AWS_REDSHIFT_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "REDSHIFT",
+            "code": "AWS_REDSHIFT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REDSHIFT",
+            "code": "AWS_REDSHIFT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "REDSHIFT",
+            "code": "AWS_REDSHIFT_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "REFACTOR_SPACES",
+            "code": "AWS_REFACTOR_SPACES_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REFACTOR_SPACES",
+            "code": "AWS_REFACTOR_SPACES_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_ARCHIVED_VIDEO_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_ARCHIVED_VIDEO_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_CUSTOM_LABELS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_CUSTOM_LABELS_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_FACE_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_FACE_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_LABELS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_LABELS_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_LIVENESS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_LIVENESS_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_STREAMING_VIDEO_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_STREAMING_VIDEO_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_TEXT_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "REKOGNITION",
+            "code": "AWS_REKOGNITION_TEXT_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "RESILIENCEHUB",
+            "code": "AWS_RESILIENCEHUB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RESILIENCEHUB",
+            "code": "AWS_RESILIENCEHUB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RESILIENCEHUB",
+            "code": "AWS_RESILIENCEHUB_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RESOURCEEXPLORER",
+            "code": "AWS_RESOURCEEXPLORER_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RESOURCEEXPLORER",
+            "code": "AWS_RESOURCEEXPLORER_CLOUDTRAIL_EVENT_DELIVERY_FAILURES",
+            "category": "issue"
+        },
+        {
+            "service": "RESOURCEEXPLORER",
+            "code": "AWS_RESOURCEEXPLORER_CONSOLE_ERRORS",
+            "category": "issue"
+        },
+        {
+            "service": "RESOURCE_GROUPS",
+            "code": "AWS_RESOURCE_GROUPS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RESOURCE_GROUPS",
+            "code": "AWS_RESOURCE_GROUPS_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "RESOURCE_GROUPS",
+            "code": "AWS_RESOURCE_GROUPS_CONSOLE_ERRORS",
+            "category": "issue"
+        },
+        {
+            "service": "RESOURCE_GROUPS",
+            "code": "AWS_RESOURCE_GROUPS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RESOURCE_GROUPS",
+            "code": "AWS_RESOURCE_GROUPS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RISK",
+            "code": "AWS_RISK_ACCOUNT_CONSOLE_COMPROMISE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "RISK",
+            "code": "AWS_RISK_CREDENTIALS_COMPROMISED",
+            "category": "issue"
+        },
+        {
+            "service": "RISK",
+            "code": "AWS_RISK_CREDENTIALS_COMPROMISE_SUSPECTED",
+            "category": "issue"
+        },
+        {
+            "service": "RISK",
+            "code": "AWS_RISK_CREDENTIALS_EXPOSED",
+            "category": "issue"
+        },
+        {
+            "service": "RISK",
+            "code": "AWS_RISK_CREDENTIALS_EXPOSURE_SUSPECTED",
+            "category": "issue"
+        },
+        {
+            "service": "RISK",
+            "code": "AWS_RISK_IAM_QUARANTINE",
+            "category": "issue"
+        },
+        {
+            "service": "ROBOMAKER",
+            "code": "AWS_ROBOMAKER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ROBOMAKER",
+            "code": "AWS_ROBOMAKER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53APPRECOVERYCONTROLLER_CLUSTER_CHANGE_PROPAGATION",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53APPRECOVERYCONTROLLER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53APPRECOVERYCONTROLLER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53APPRECOVERYCONTROLLER_RECOVERY_CLUSTER_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53APPRECOVERYCONTROLLER_RECOVERY_CONTROL_CONFIG_AVAILABILITY",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53APPRECOVERYCONTROLLER_RECOVERY_CONTROL_CONFIG_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53APPRECOVERYCONTROLLER_RECOVERY_READINESS_AVAILABILITY",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53APPRECOVERYCONTROLLER_RECOVERY_READINESS_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53APPRECOVERYCONTROLLER_RECOVERY_READINESS_RULES_EVALUATION_AVAILABILITY",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53DOMAINREGISTRATION",
+            "code": "AWS_ROUTE53DOMAINREGISTRATION_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53DOMAINREGISTRATION",
+            "code": "AWS_ROUTE53DOMAINREGISTRATION_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53DOMAINREGISTRATION",
+            "code": "AWS_ROUTE53DOMAINREGISTRATION_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ROUTE53PRIVATEDNS",
+            "code": "AWS_ROUTE53PRIVATEDNS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53PRIVATEDNS",
+            "code": "AWS_ROUTE53PRIVATEDNS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53PRIVATEDNS",
+            "code": "AWS_ROUTE53PRIVATEDNS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ROUTE53RESOLVER",
+            "code": "AWS_ROUTE53RESOLVER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53RESOLVER",
+            "code": "AWS_ROUTE53RESOLVER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_DOMAIN_REGISTRATION_TRANSFER_ERROR_RATE",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_IDENTITY_PROOF_REQUIRED",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_NEW_INSTANCES_PRIVATE_DNS_RESOLUTION",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ROUTE53APPRECOVERYCONTROLLER",
+            "code": "AWS_ROUTE53_RECOVERY_READINESS_RULE_MONITORING_AVAILABILITY",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_SLOW_PROPAGATION_HEALTH_CHECK_STATUSES",
+            "category": "issue"
+        },
+        {
+            "service": "ROUTE53",
+            "code": "AWS_ROUTE53_SLOW_PROPAGATION_TIMES",
+            "category": "issue"
+        },
+        {
+            "service": "RUM",
+            "code": "AWS_RUM_CONTROLPLANE_COMPOSITE_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "RUM",
+            "code": "AWS_RUM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "RUM",
+            "code": "AWS_RUM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_INCREASED_GET_API_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_INCREASED_GET_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_INCREASED_PUT_API_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_INCREASED_PUT_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_OPEN_ACCESS_BUCKET_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "S3_OUTPOSTS",
+            "code": "AWS_S3_OUTPOSTS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "S3_OUTPOSTS",
+            "code": "AWS_S3_OUTPOSTS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_PRIVATELINK_AVAILABILITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_PRIVATELINK_LATENCY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "S3_REPLICATION_TIME_CONTROL",
+            "code": "AWS_S3_REPLICATION_TIME_CONTROL_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "S3_REPLICATION_TIME_CONTROL",
+            "code": "AWS_S3_REPLICATION_TIME_CONTROL_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "S3_REPLICATION_TIME_CONTROL",
+            "code": "AWS_S3_REPLICATION_TIME_CONTROL_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "S3",
+            "code": "AWS_S3_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_BATCH_METRIC_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_GROUNDTRUTH_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_HPO_WORKFLOW_FAULT",
+            "category": "issue"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_INFERENCE_RECOMMENDER_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_MODELCARDS_WORKFLOW_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_NOTEBOOK_INSTANCE_RETIREMENT",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_PIPELINES_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_SCHEDULED_MAINTENANCE",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SAGEMAKER",
+            "code": "AWS_SAGEMAKER_STUDIO_KERNEL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SDB",
+            "code": "AWS_SDB_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SDB",
+            "code": "AWS_SDB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SDB",
+            "code": "AWS_SDB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SDK",
+            "code": "AWS_SDK_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECRETSMANAGER",
+            "code": "AWS_SECRETSMANAGER_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECRETSMANAGER",
+            "code": "AWS_SECRETSMANAGER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SECRETSMANAGER",
+            "code": "AWS_SECRETSMANAGER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECRETSMANAGER",
+            "code": "AWS_SECRETSMANAGER_RDS_MANAGED_SECRET_ROTATION_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SECRETSMANAGER",
+            "code": "AWS_SECRETSMANAGER_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITYHUB",
+            "code": "AWS_SECURITYHUB_MEMBER_LIMIT_REACHED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITYHUB",
+            "code": "AWS_SECURITYHUB_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITYHUB",
+            "code": "AWS_SECURITYHUB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SECURITYHUB",
+            "code": "AWS_SECURITYHUB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITYHUB",
+            "code": "AWS_SECURITYHUB_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITYHUB",
+            "code": "AWS_SECURITYHUB_SERVICE_ENABLEMENT_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITYLAKE",
+            "code": "AWS_SECURITYLAKE_BUCKET_INACCESSIBLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITYLAKE",
+            "code": "AWS_SECURITYLAKE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SECURITYLAKE",
+            "code": "AWS_SECURITYLAKE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITY",
+            "code": "AWS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITY",
+            "code": "AWS_SECURITY_TLS_DEPRECATION_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SECURITY",
+            "code": "AWS_SECURITY_TLS_DEPRECATION_NOTIFICATION_REMINDER",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SERVERLESSREPO",
+            "code": "AWS_SERVERLESSREPO_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SERVERLESSREPO",
+            "code": "AWS_SERVERLESSREPO_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SERVERLESSREPO",
+            "code": "AWS_SERVERLESSREPO_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SERVICECATALOG",
+            "code": "AWS_SERVICECATALOG_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SERVICECATALOG",
+            "code": "AWS_SERVICECATALOG_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SERVICECATALOG",
+            "code": "AWS_SERVICECATALOG_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SERVICEDISCOVERY",
+            "code": "AWS_SERVICEDISCOVERY_CONSOLE_INCREASED_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "SERVICEDISCOVERY",
+            "code": "AWS_SERVICEDISCOVERY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SERVICEDISCOVERY",
+            "code": "AWS_SERVICEDISCOVERY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SERVICEDISCOVERY",
+            "code": "AWS_SERVICEDISCOVERY_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SERVICEQUOTAS",
+            "code": "AWS_SERVICEQUOTAS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SERVICEQUOTAS",
+            "code": "AWS_SERVICEQUOTAS_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "SERVICEQUOTAS",
+            "code": "AWS_SERVICEQUOTAS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SERVICEQUOTAS",
+            "code": "AWS_SERVICEQUOTAS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_CMF_PENDING_TO_FAILED",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_CMF_PENDING_TO_SUCCESS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_CMF_SUCCESS_TO_TEMPORARY_FAILURE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_CMF_TEMPORARY_FAILURE_TO_FAILED",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_CMF_TEMPORARY_FAILURE_TO_SUCCESS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_DEPRECATED_CREDENTIALS_USAGE_SIGV3",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_DKIM_FAILED_TO_VERIFIED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_DKIM_PENDING_TO_FAILED",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_DKIM_PENDING_TO_VERIFIED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_DKIM_VERIFIED_TO_FAILED",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_ENFORCEMENT_HEAL",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_ENFORCEMENT_PROBATION",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_ENFORCEMENT_SHUTDOWN",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_ESM_FIREHOSE_STREAM_ENABLED_TO_DISABLED",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_ESM_SNS_TOPIC_ENABLED_TO_DISABLED",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_HEAL",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_PROBATION",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_SHUTDOWN",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_SNS_PUBLISH_FAILURE",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_VERIFICATION_FAILING",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_VERIFICATION_PENDING_TO_FAILED",
+            "category": "issue"
+        },
+        {
+            "service": "SES",
+            "code": "AWS_SES_VERIFICATION_PENDING_TO_SUCCESS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_ADVANCED_SUBSCRIPTION_RENEWAL_COMING_UP",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_ADVANCED_SUBSCRIPTION_RENEWED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_INTERNET_TRAFFIC_LIMITATIONS_PLACED_IN_RESPONSE_TO_DDOS_ATTACK",
+            "category": "issue"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_IS_RESPONDING_TO_A_DDOS_ATTACK_AGAINST_YOUR_AWS_RESOURCES",
+            "category": "issue"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_PROACTIVE_RESPONSE_ENABLED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_PROACTIVE_RESPONSE_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_PROACTIVE_RESPONSE_WHITELISTING_IN_PROGRESS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SHIELD",
+            "code": "AWS_SHIELD_SUBSCRIPTION_EXPIRES_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SIGNIN",
+            "code": "AWS_SIGNIN_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SIGNIN",
+            "code": "AWS_SIGNIN_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SIGNIN",
+            "code": "AWS_SIGNIN_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SIMSPACEWEAVER",
+            "code": "AWS_SIMSPACEWEAVER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SIMSPACEWEAVER",
+            "code": "AWS_SIMSPACEWEAVER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SMS",
+            "code": "AWS_SMS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_DELAY_IN_TRANSIT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_IN_TRANSIT_TO_AWS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_LCS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_LTP_NON_RENEW_10_DAYS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_LTP_NON_RENEW_30_DAYS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_LTP_RENEW_10_DAYS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_LTP_RENEW_30_DAYS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_LTP_RENEW_60_DAYS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_LTP_RENEW_LAST_DAY",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_LTP_RENEW_NO_JOB",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_PENDING_CARRIER",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNOWBALL",
+            "code": "AWS_SNOWBALL_SORT_FACILITY",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNS",
+            "code": "AWS_SNS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SNS",
+            "code": "AWS_SNS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNS",
+            "code": "AWS_SNS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SNS",
+            "code": "AWS_SNS_SES_ABUSE_DETECTION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SQS",
+            "code": "AWS_SQS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SQS",
+            "code": "AWS_SQS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SQS",
+            "code": "AWS_SQS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SQS",
+            "code": "AWS_SQS_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SSM-SAP",
+            "code": "AWS_SSM-SAP_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SSM-SAP",
+            "code": "AWS_SSM-SAP_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SSM",
+            "code": "AWS_SSM_AGENT_OPERATING_SYSTEM_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SSM",
+            "code": "AWS_SSM_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SSM",
+            "code": "AWS_SSM_IM_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SSM_INCIDENTS",
+            "code": "AWS_SSM_INCIDENTS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SSM_INCIDENTS",
+            "code": "AWS_SSM_INCIDENTS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SSM",
+            "code": "AWS_SSM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SSM",
+            "code": "AWS_SSM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SSM",
+            "code": "AWS_SSM_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SSO",
+            "code": "AWS_SSO_ACCESS_PORTAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SSO",
+            "code": "AWS_SSO_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SSO",
+            "code": "AWS_SSO_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SSO",
+            "code": "AWS_SSO_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SSO",
+            "code": "AWS_SSO_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "STATES",
+            "code": "AWS_STATES_INCREASED_API_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "STATES",
+            "code": "AWS_STATES_INCREASED_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "STATES",
+            "code": "AWS_STATES_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "STATES",
+            "code": "AWS_STATES_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "STATES",
+            "code": "AWS_STATES_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "STATES",
+            "code": "AWS_STATES_SYNC_EXPRESS_API_FAULTS",
+            "category": "issue"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_GATEWAY_VM_DEPRECATED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_GATEWAY_VM_DEPRECATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_HARDWARE_APPLIANCE_GATEWAY_VM_SOFTWARE_DEPRECATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_INCREASED_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_SOFTWARE_UPDATE_AVAILABLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "STORAGEGATEWAY",
+            "code": "AWS_STORAGEGATEWAY_VM_DEPRECATED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SUMERIAN",
+            "code": "AWS_SUMERIAN_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SUMERIAN",
+            "code": "AWS_SUMERIAN_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SUMERIAN",
+            "code": "AWS_SUMERIAN_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SUPPORTCENTER",
+            "code": "AWS_SUPPORTCENTER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SUPPORTCENTER",
+            "code": "AWS_SUPPORTCENTER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "SWAY",
+            "code": "AWS_SWAY_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SWF",
+            "code": "AWS_SWF_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SWF",
+            "code": "AWS_SWF_INCREASED_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "SWF",
+            "code": "AWS_SWF_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "SWF",
+            "code": "AWS_SWF_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TAG",
+            "code": "AWS_TAG_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TAG",
+            "code": "AWS_TAG_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TAG",
+            "code": "AWS_TAG_POLICY_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TAG",
+            "code": "AWS_TAG_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TESTSERVICE",
+            "code": "AWS_TESTSERVICE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TEXTRACT",
+            "code": "AWS_TEXTRACT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TEXTRACT",
+            "code": "AWS_TEXTRACT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TIMESTREAM",
+            "code": "AWS_TIMESTREAM_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TIMESTREAM",
+            "code": "AWS_TIMESTREAM_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TNB",
+            "code": "AWS_TNB_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "TNB",
+            "code": "AWS_TNB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TNB",
+            "code": "AWS_TNB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TRAFFICMIRRORING",
+            "code": "AWS_TRAFFICMIRRORING_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TRAFFICMIRRORING",
+            "code": "AWS_TRAFFICMIRRORING_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TRANSCRIBE",
+            "code": "AWS_TRANSCRIBE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TRANSCRIBE",
+            "code": "AWS_TRANSCRIBE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TRANSCRIBE",
+            "code": "AWS_TRANSCRIBE_STREAMING_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TRANSFER",
+            "code": "AWS_TRANSFER_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TRANSFER",
+            "code": "AWS_TRANSFER_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TRANSFER",
+            "code": "AWS_TRANSFER_SERVER_LOGGING_ROLE_NOT_ASSUMABLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TRANSIT_GATEWAY",
+            "code": "AWS_TRANSIT_GATEWAY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TRANSIT_GATEWAY",
+            "code": "AWS_TRANSIT_GATEWAY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TRANSIT_GATEWAY",
+            "code": "AWS_TRANSIT_GATEWAY_PACKET_LOSS_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TRANSLATE",
+            "code": "AWS_TRANSLATE_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TRANSLATE",
+            "code": "AWS_TRANSLATE_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TRUSTEDADVISOR",
+            "code": "AWS_TRUSTEDADVISOR_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TRUSTEDADVISOR",
+            "code": "AWS_TRUSTEDADVISOR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "TRUSTEDADVISOR",
+            "code": "AWS_TRUSTEDADVISOR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "TRUSTEDADVISOR",
+            "code": "AWS_TRUSTEDADVISOR_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VERIFIED_ACCESS",
+            "code": "AWS_VERIFIED_ACCESS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VERIFIED_ACCESS",
+            "code": "AWS_VERIFIED_ACCESS_API_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "VERIFIED_ACCESS",
+            "code": "AWS_VERIFIED_ACCESS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VERIFIED_ACCESS",
+            "code": "AWS_VERIFIED_ACCESS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VERIFIED_PERMISSIONS",
+            "code": "AWS_VERIFIED_PERMISSIONS_OPERATIONAL_INVESTIGATION",
+            "category": "investigation"
+        },
+        {
+            "service": "VERIFIED_PERMISSIONS",
+            "code": "AWS_VERIFIED_PERMISSIONS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VERIFIED_PERMISSIONS",
+            "code": "AWS_VERIFIED_PERMISSIONS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VMIMPORTEXPORT",
+            "code": "AWS_VMIMPORTEXPORT_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VMIMPORTEXPORT",
+            "code": "AWS_VMIMPORTEXPORT_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPCE_PRIVATELINK",
+            "code": "AWS_VPCE_PRIVATELINK_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPCE_PRIVATELINK",
+            "code": "AWS_VPCE_PRIVATELINK_FLOW_LOGS_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VPCE_PRIVATELINK",
+            "code": "AWS_VPCE_PRIVATELINK_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VPCE_PRIVATELINK",
+            "code": "AWS_VPCE_PRIVATELINK_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPC",
+            "code": "AWS_VPC_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VPC",
+            "code": "AWS_VPC_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VPC",
+            "code": "AWS_VPC_INCREASED_MANAGEMENT_CONSOLE_ERROR_RATES",
+            "category": "issue"
+        },
+        {
+            "service": "VPC_LATTICE",
+            "code": "AWS_VPC_LATTICE_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VPC_LATTICE",
+            "code": "AWS_VPC_LATTICE_API_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "VPC_LATTICE",
+            "code": "AWS_VPC_LATTICE_CLOUDWATCH_METRICS_DELAY",
+            "category": "issue"
+        },
+        {
+            "service": "VPC_LATTICE",
+            "code": "AWS_VPC_LATTICE_CONFIGURATION_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VPC_LATTICE",
+            "code": "AWS_VPC_LATTICE_NETWORK_CONNECTIVITY_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VPC_LATTICE",
+            "code": "AWS_VPC_LATTICE_PROVISIONING_LATENCIES",
+            "category": "issue"
+        },
+        {
+            "service": "VPC",
+            "code": "AWS_VPC_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VPC",
+            "code": "AWS_VPC_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPC",
+            "code": "AWS_VPC_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_CLASSIC_DX_MIGRATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_CLASSIC_RETIREMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_CLASSIC_RETIREMENT_JP",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_EMERGENCY_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_MAINTENANCE_CANCELLED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_REDUNDANCY_LOSS",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_SINGLE_TUNNEL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "VPN",
+            "code": "AWS_VPN_TUNNEL_UPDATE_AVAILABLE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WAF",
+            "code": "AWS_WAF_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WAF",
+            "code": "AWS_WAF_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WAF",
+            "code": "AWS_WAF_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WAF",
+            "code": "AWS_WAF_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WAF",
+            "code": "AWS_WAF_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WELLARCHITECTED",
+            "code": "AWS_WELLARCHITECTED_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WELLARCHITECTED",
+            "code": "AWS_WELLARCHITECTED_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WELLARCHITECTED",
+            "code": "AWS_WELLARCHITECTED_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WICKR",
+            "code": "AWS_WICKR_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WICKR",
+            "code": "AWS_WICKR_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKDOCS",
+            "code": "AWS_WORKDOCS_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WORKDOCS",
+            "code": "AWS_WORKDOCS_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WORKDOCS",
+            "code": "AWS_WORKDOCS_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_AUP_SENDING_BLOCKED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_AUP_SENDING_BLOCKED_IMMEDIATE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_AUP_SENDING_LIMITED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_BOUNCE_SENDING_BLOCKED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_BOUNCE_SENDING_BLOCKED_IMMEDIATE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_BOUNCE_SENDING_LIMITED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_BOUNCE_SENDING_WARNING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_BOUNCE_WARNING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_COMPLAINT_SENDING_BLOCKED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_COMPLAINT_SENDING_BLOCKED_IMMEDIATE",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_COMPLAINT_SENDING_LIMITED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_COMPLAINT_SENDING_WARNING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_COMPLAINT_WARNING",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_DELAYED_EMAIL_DELIVERY",
+            "category": "issue"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_JOURNALING_DISABLED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_ORGANIZATION_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WORKMAIL",
+            "code": "AWS_WORKMAIL_VULN_COMP_CRED_BLOCKED_OR_LIMITED",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKSPACESWEB",
+            "code": "AWS_WORKSPACESWEB_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WORKSPACESWEB",
+            "code": "AWS_WORKSPACESWEB_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKSPACES",
+            "code": "AWS_WORKSPACES_API_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WORKSPACES",
+            "code": "AWS_WORKSPACES_CONSOLE_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WORKSPACES",
+            "code": "AWS_WORKSPACES_CONSOLE_LATENCY",
+            "category": "issue"
+        },
+        {
+            "service": "WORKSPACES",
+            "code": "AWS_WORKSPACES_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKSPACES",
+            "code": "AWS_WORKSPACES_MAINTENANCE_SCHEDULED",
+            "category": "scheduledChange"
+        },
+        {
+            "service": "WORKSPACES",
+            "code": "AWS_WORKSPACES_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "WORKSPACES",
+            "code": "AWS_WORKSPACES_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "WORKSPACES",
+            "code": "AWS_WORKSPACES_SECURITY_NOTIFICATION",
+            "category": "accountNotification"
+        },
+        {
+            "service": "XRAY",
+            "code": "AWS_XRAY_CUSTOMER_ENGAGEMENT",
+            "category": "accountNotification"
+        },
+        {
+            "service": "XRAY",
+            "code": "AWS_XRAY_OPERATIONAL_ISSUE",
+            "category": "issue"
+        },
+        {
+            "service": "XRAY",
+            "code": "AWS_XRAY_OPERATIONAL_NOTIFICATION",
+            "category": "accountNotification"
+        }
+    ]
+}


### PR DESCRIPTION
Adding a list of all event types are reported by `describe-event-types`.  

*Issue #, if available:*

*Description of changes:*
Please feel free to provide any sort of criticism or suggestions. I don't see a list of All events in the [AWS Health Documentation](https://docs.aws.amazon.com/health/latest/ug/doc-history.html) and some entity security postures limit both the installation of the AWS CLI and the use of CloudShell to run the `describe-event-types` commands. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
