### PR TITLE
Update DX Notifier from Node18->22

### DIFF
--- a/dx-maintenance-notifier/DX_Notifier.json
+++ b/dx-maintenance-notifier/DX_Notifier.json
@@ -151,7 +151,7 @@
             ]
           }
         },
-        "Runtime": "nodejs18.x",
+        "Runtime": "nodejs22.x",
         "Timeout": "25"
       }
     },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating the Node version of the DX Notifier Lambda


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
