### PR TITLE
chore(dependabot): Add specific directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,18 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/automated-actions/ECS_TASK_PATCHING_AUTOMATION"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/high-availability-endpoint/python"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "gradle"
+    directory: "/high-availability-endpoint/java"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Add coverage for specific directories that have requirements listed along with gradle for Java code.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
