### PR TITLE
docs: clarify S3 replication script works with any AWS region

### DIFF
--- a/misc/S3-replication-script/README.md
+++ b/misc/S3-replication-script/README.md
@@ -3,7 +3,7 @@
 ## Goal
 
 This script is designed to quickly setup replication between a source bucket and a destination bucket.
-This script is primarily intended to assist with migration from me-central-1.
+This script is primarily intended to assist with migration from me-central-1. You can use this script to setup a one-time S3 batch replication job from any AWS region by specifying the `--source-region` command line argument.
 
 ## Requirements
 


### PR DESCRIPTION
Add note that --source-region argument enables use with any AWS region, not just me-central-1.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
