### PR TITLE
security: fix GHSA-xvcq-hx64-q4rj — restrict Elasticsearch access policy and remove insecure defaults

### DIFF
--- a/automated-actions/AWS_EBS_VOLUME_LOST/SydneySummitDemo/aws_ebs_vol_lost_cfn.yaml
+++ b/automated-actions/AWS_EBS_VOLUME_LOST/SydneySummitDemo/aws_ebs_vol_lost_cfn.yaml
@@ -104,9 +104,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: '*'
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
             Action: 'es:*'
-            Resource: '*'
+            Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/*'
 
   ElasticsearchSecurityGroup:
       Type: "AWS::EC2::SecurityGroup"

--- a/automated-actions/AWS_EBS_VOLUME_LOST/stepbystep/README.md
+++ b/automated-actions/AWS_EBS_VOLUME_LOST/stepbystep/README.md
@@ -1,5 +1,8 @@
 # Amazon EBS Volume Lost Recovery Automation using AWS Health
 
+> **⚠️ SECURITY WARNING:** These templates deploy an Elasticsearch/Kibana environment with a public-facing proxy. Ensure you restrict the `PublicCidr` parameter to your specific IP address (e.g. `1.2.3.4/32`). **Never use `0.0.0.0/0`** — it exposes the deployment to unauthenticated public access. These templates are provided for educational/workshop purposes only and should not be used in production without additional hardening (HTTPS, authentication, restrictive security groups).
+
+
 In an extremely rare scenario when an EBS volume is reported as lost due to multiple underlying hardware failure, you can recover the affected EC2 instance from a recent Amazon Machine Image (AMI) backup. In this automated solution we will do the following;
 
 * Check if the affected EBS volume is attached as a root volume of an EC2 instance. 
@@ -43,7 +46,7 @@ We have encapsulated the Elasticsearch configuration and deployment steps into a
 5. Upload the file named *step\_1\_es\_ec2proxy\_reinvent\_workshop.yml*.
 6. Click **Next**.
 7. Enter a **Stack name**. Example: `ebs-es-reinvent`
-8. Enter a public CIDR that Kibana will be accessible from. This is the public IP range that you will be accessing the dashboard from. (If you aren't sure, you can find your public IP at https://www.myip.com/ and then append a /32 suffix to it. For example, if your public IP was `1.2.3.4`, you would use: `1.2.3.4/32`. For demo purposes, you can enter the CICR as `0.0.0.0/0`).
+8. Enter a public CIDR that Kibana will be accessible from. This is the public IP range that you will be accessing the dashboard from. (If you aren't sure, you can find your public IP at https://www.myip.com/ and then append a /32 suffix to it. For example, if your public IP was `1.2.3.4`, you would use: `1.2.3.4/32`. **Security warning: Do NOT use `0.0.0.0/0` — this exposes your Elasticsearch/Kibana deployment to the entire internet without authentication.** Use your specific IP with a `/32` suffix (e.g. `1.2.3.4/32`)).
 9. Click **Next**.
 10. If desired, tag the resources by entering `Name` as the Key and `kibana_es_reinvent` as the Value.
 11. Click **Next**.

--- a/automated-actions/AWS_EBS_VOLUME_LOST/stepbystep/step_1_es_ec2proxy_reinvent_workshop.yml
+++ b/automated-actions/AWS_EBS_VOLUME_LOST/stepbystep/step_1_es_ec2proxy_reinvent_workshop.yml
@@ -5,7 +5,7 @@ Parameters:
     Description: The public IP address that Kibana will be accessible from.
     MinLength: 9
     MaxLength: 18
-    Default: "0.0.0.0/0"
+    Default: "10.0.0.0/8"
     AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
     ConstraintDescription: "must be a valid IP CIDR range of the form x.x.x.x/x."
 
@@ -225,9 +225,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: '*'
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
             Action: 'es:*'
-            Resource: '*'
+            Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/*'
 
   ElasticsearchSecurityGroup:
       Type: "AWS::EC2::SecurityGroup"


### PR DESCRIPTION
## Security Advisory

Fixes [GHSA-xvcq-hx64-q4rj](https://github.com/aws/aws-health-tools/security/advisories/GHSA-xvcq-hx64-q4rj) — AWS_EBS_VOLUME_LOST templates expose a VPC Elasticsearch/Kibana deployment to unauthenticated public access.

## Changes

### 1. Restrict Elasticsearch access policy (both templates)

**Before:**
```yaml
AccessPolicies:
  Statement:
    - Effect: Allow
      Principal:
        AWS: '*'
      Action: 'es:*'
      Resource: '*'
```

**After:**
```yaml
AccessPolicies:
  Statement:
    - Effect: Allow
      Principal:
        AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
      Action: 'es:*'
      Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/*'
```

This scopes access to the deploying account only, following AWS least-privilege best practices.

### 2. Remove insecure CIDR default (stepbystep template)

Changed `PublicCidr` default from `0.0.0.0/0` (entire internet) to `10.0.0.0/8` (private range). Users must now explicitly provide their IP.

### 3. Add security warnings to README

- Added prominent security warning banner at the top
- Replaced "you can enter the CIDR as `0.0.0.0/0`" with explicit warning against it

## Files changed

| File | Change |
|------|--------|
| `stepbystep/step_1_es_ec2proxy_reinvent_workshop.yml` | Access policy scoped to account + CIDR default changed |
| `SydneySummitDemo/aws_ebs_vol_lost_cfn.yaml` | Access policy scoped to account |
| `stepbystep/README.md` | Security warning added, insecure guidance removed |
