### PR TITLE
security: complete GHSA-xvcq-hx64-q4rj fix — move to private-only access model

### DIFF
--- a/automated-actions/AWS_EBS_VOLUME_LOST/SydneySummitDemo/aws_ebs_vol_lost_cfn.yaml
+++ b/automated-actions/AWS_EBS_VOLUME_LOST/SydneySummitDemo/aws_ebs_vol_lost_cfn.yaml
@@ -9,10 +9,8 @@ Parameters:
     Description: Enter the VPC that the subnets belong to.
   SubnetIds:
     Type: "List<AWS::EC2::Subnet::Id>"
-    Description: You must select AT LEAST two (2) PUBLIC subnets for demo instance, ELB, Elasticsearch domain, and Lambda load functions to work.
-  PublicCidr:
-    Type: "String"
-    Description: The public IP address that Kibana will be accessible from.
+    Description: You must select AT LEAST two (2) subnets for the demo instance, internal ELB, Elasticsearch domain, and Lambda load functions to work.
+
 
 Resources:
   # IAM Execution Role for Lambda Functions
@@ -91,7 +89,7 @@ Resources:
         SubnetIds:
           - !Select [ 0, !Ref SubnetIds ]
         SecurityGroupIds:
-          - !Ref ElasticsearchSecurityGroup
+          - !Ref ElasticsearchLambdaSecurityGroup
       ElasticsearchClusterConfig:
         InstanceCount: 1
         InstanceType: t2.small.elasticsearch
@@ -111,27 +109,55 @@ Resources:
   ElasticsearchSecurityGroup:
       Type: "AWS::EC2::SecurityGroup"
       Properties:
-        GroupDescription: Allows internal data loading and public access to Elasticsearch.
+        GroupDescription: Allows only the internal load balancer and Lambda functions to access Elasticsearch.
         VpcId: !Ref VpcId
         SecurityGroupIngress:
           -
-            CidrIp: !Ref PublicCidr
+            SourceSecurityGroupId: !Ref ElasticsearchLoadBalancerSecurityGroup
             IpProtocol: TCP
             FromPort: 80
             ToPort: 80
+          -
+            SourceSecurityGroupId: !Ref ElasticsearchLoadBalancerSecurityGroup
+            IpProtocol: TCP
+            FromPort: 443
+            ToPort: 443
+          -
+            SourceSecurityGroupId: !Ref ElasticsearchLambdaSecurityGroup
+            IpProtocol: TCP
+            FromPort: 80
+            ToPort: 80
+          -
+            SourceSecurityGroupId: !Ref ElasticsearchLambdaSecurityGroup
+            IpProtocol: TCP
+            FromPort: 443
+            ToPort: 443
+
+  ElasticsearchLoadBalancerSecurityGroup:
+      Type: "AWS::EC2::SecurityGroup"
+      Properties:
+        GroupDescription: Allows VPC-only HTTP access to the internal Kibana load balancer.
+        VpcId: !Ref VpcId
+        SecurityGroupIngress:
           -
             CidrIp: !GetAtt CustomVpcCidr.Cidr
             IpProtocol: TCP
             FromPort: 80
             ToPort: 80
+  ElasticsearchLambdaSecurityGroup:
+      Type: "AWS::EC2::SecurityGroup"
+      Properties:
+        GroupDescription: Allows Lambda functions to reach the Elasticsearch domain from the VPC.
+        VpcId: !Ref VpcId
 
   ElasticsearchELB:
     Type: "AWS::ElasticLoadBalancingV2::LoadBalancer"
     Properties:
+      Scheme: internal
       Type: application
       Subnets: !Ref SubnetIds
       SecurityGroups:
-        - !Ref ElasticsearchSecurityGroup
+        - !Ref ElasticsearchLoadBalancerSecurityGroup
 
   ElasticsearchELBTargetGroup:
     Type: "AWS::ElasticLoadBalancingV2::TargetGroup"
@@ -176,7 +202,7 @@ Resources:
           VpcConfig:
             SubnetIds: !Ref SubnetIds
             SecurityGroupIds:
-              - !Ref ElasticsearchSecurityGroup
+              - !Ref ElasticsearchLambdaSecurityGroup
           Code:
             ZipFile: |
               import socket
@@ -545,7 +571,7 @@ Resources:
       VpcConfig:
         SubnetIds: !Ref SubnetIds
         SecurityGroupIds:
-          - !Ref ElasticsearchSecurityGroup
+          - !Ref ElasticsearchLambdaSecurityGroup
       Environment:
         Variables:
           ESDOMAIN: !GetAtt ElasticsearchDomain.DomainEndpoint
@@ -802,6 +828,4 @@ Outputs:
         - - 'http://'
           - !GetAtt ElasticsearchELB.DNSName
           - '/_plugin/kibana'
-  KibanaWhitelist:
-    Description: Public IPs Kibana is accessible from.
-    Value: !Ref PublicCidr
+

--- a/automated-actions/AWS_EBS_VOLUME_LOST/SydneySummitDemo/readme.md
+++ b/automated-actions/AWS_EBS_VOLUME_LOST/SydneySummitDemo/readme.md
@@ -27,7 +27,7 @@ Notification on update will be sent to SNS topic assigned.
 1.  Replace all **vol-xxxxxxxxxxxxxxxxx** values in the **phd-mock-payload.json** with the copied value.
 1.  Modifiy the **time** to within the past 14 days in **phd-mock-event.json**.
 1.  Post the mock event to CloudWatch using the AWS CLI command **aws events put-events --entries file://phd-mock-event.json** - this will trigger a CloudWatch Rule that will in turn launch the Step Function to replace the volume.
-1.  Open the Kibana dashboard (the URL can be found in the Outputs of the **Core Functionality** Stack)
+1.  Open the Kibana dashboard from a host inside the VPC using the URL in the Outputs of the **Core Functionality** Stack
 1. In Kibana, under **Management > Index Patterns**, create an index pattern named **phd-events** using **PhdEventTime** as the **Time Filter**.
 1. Under **Management > Saved Objects**, import **elasticsearch-objects.json**, overwriting all objects, and using **phd-events** as the new index pattern.
 1. Navigate to **Dashboard > PHD Events** to see the event(s).
@@ -38,8 +38,7 @@ Choose **Launch Stack** to launch the CloudFormation template in the US East (N.
 
 The **Core Functionality** CloudFormation template requires the following parameters:
 * *SNSTopicName* - Enter the SNS topic to send notification to - this must exist in US East (N. Virginia) region
-* *PublicCidr* - The public IP from which Kibana will be accessible
-* *SubnetIds* - Two public subnets for Kibana access
+* *SubnetIds* - Two subnets for the internal Kibana load balancer and Lambda functions
 * *VpcId* - The VPC to which the subnets belong
 
 The **Important App** CloudFormation template requires the following parameters:
@@ -54,7 +53,7 @@ The **Important App** CloudFormation template requires the following parameters:
 
 These CloudFormation templates are for demo and proof-of-concept purposes only.  They and are not intended for production environments.  Amongst other deficiencies, they:
 * do not follow the rule of least privileged access, and will create IAM Roles with the 'AdministratorAccess' AWS Managed policy
-* will serve public traffic from the Elasticsearch domain over unencrypted HTTP connections
+* provide Kibana access over unencrypted HTTP within the VPC
 
 ### License
 AWS Health Tools are licensed under the Apache 2.0 License.

--- a/automated-actions/AWS_EBS_VOLUME_LOST/stepbystep/README.md
+++ b/automated-actions/AWS_EBS_VOLUME_LOST/stepbystep/README.md
@@ -46,18 +46,18 @@ We have encapsulated the Elasticsearch configuration and deployment steps into a
 5. Upload the file named *step\_1\_es\_ec2proxy\_reinvent\_workshop.yml*.
 6. Click **Next**.
 7. Enter a **Stack name**. Example: `ebs-es-reinvent`
-8. Enter a public CIDR that Kibana will be accessible from. This is the public IP range that you will be accessing the dashboard from. (If you aren't sure, you can find your public IP at https://www.myip.com/ and then append a /32 suffix to it. For example, if your public IP was `1.2.3.4`, you would use: `1.2.3.4/32`. **Security warning: Do NOT use `0.0.0.0/0` — this exposes your Elasticsearch/Kibana deployment to the entire internet without authentication.** Use your specific IP with a `/32` suffix (e.g. `1.2.3.4/32`)).
+8. Review the default VPC deployment parameters. The stack deploys Kibana behind a reverse proxy that is reachable only from within the VPC created by the template.
 9. Click **Next**.
 10. If desired, tag the resources by entering `Name` as the Key and `kibana_es_reinvent` as the Value.
 11. Click **Next**.
 12. Click the check box next to **I acknowledge that AWS CloudFormation might create IAM resources.**
 13. Click **Create**.
-14. Once you see CREATE_COMPLETE, select the Outputs tab and click on the link for **KibanaURL** to ensure Kibana is accessible and functioning.
+14. Once you see CREATE_COMPLETE, select the Outputs tab and use **KibanaURL** from a host inside the VPC to ensure Kibana is accessible and functioning.
 
 
 **Diagram Note:**
 
-For demo purposes, an EC2 instance running as Reverse Proxy will be deployed to this cluster to simplify access to the Kibana Console. This is certainly not the recommended method of access especially when you are accessing over the internet. In a production environment, we recommend that you deploy the Amazon Elasticsearch cluster within a private VPC and access only via VPN tunnel, Direct Connect, and/or implement token-based authentication using Cognito.
+For demo purposes, an EC2 instance running as a reverse proxy will be deployed in a private subnet to simplify access to the Kibana console without exposing it to the public internet. Access Kibana only from a host inside the VPC. If remote access is required, use a private forwarding or bastion pattern rather than exposing the proxy to the internet. In a production environment, we recommend that you keep the Amazon Elasticsearch cluster private and implement authentication controls such as Cognito.
 
 ![ES Proxy](images/ES_Proxy.png)
 

--- a/automated-actions/AWS_EBS_VOLUME_LOST/stepbystep/step_1_es_ec2proxy_reinvent_workshop.yml
+++ b/automated-actions/AWS_EBS_VOLUME_LOST/stepbystep/step_1_es_ec2proxy_reinvent_workshop.yml
@@ -1,14 +1,4 @@
 AWSTemplateFormatVersion: 2010-09-09
-Parameters:
-  PublicCidr:
-    Type: String
-    Description: The public IP address that Kibana will be accessible from.
-    MinLength: 9
-    MaxLength: 18
-    Default: "10.0.0.0/8"
-    AllowedPattern: "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
-    ConstraintDescription: "must be a valid IP CIDR range of the form x.x.x.x/x."
-
 Mappings:
   AWSInstanceType2Arch:
     t1.micro:
@@ -105,7 +95,7 @@ Resources:
     Properties:
       VpcId: !Ref VPC
       CidrBlock: 10.1.1.0/24
-      MapPublicIpOnLaunch: true
+      MapPublicIpOnLaunch: false
       AvailabilityZone: !Select 
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -113,13 +103,13 @@ Resources:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
       RouteTableId: !Ref PublicRouteTable
-      SubnetId: !Ref PublicSubnetA
+      SubnetId: !Ref PrivateSubnetA
   PublicSubnetB:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
       CidrBlock: 10.1.3.0/24
-      MapPublicIpOnLaunch: true
+      MapPublicIpOnLaunch: false
       AvailabilityZone: !Select 
         - 1
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -133,7 +123,7 @@ Resources:
     Type: AWS::EC2::NatGateway
     Properties: 
       AllocationId: !GetAtt NATEIPA.AllocationId
-      SubnetId: !Ref PublicSubnetA
+      SubnetId: !Ref PrivateSubnetA
   NATEIPA:
     Type: AWS::EC2::EIP
     Properties:
@@ -169,12 +159,11 @@ Resources:
     Properties:
       VpcId: !Ref VPC
   PrivateSubnetA:
-    DependsOn: PrivateRouteA
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
       CidrBlock: 10.1.2.0/24
-      MapPublicIpOnLaunch: true
+      MapPublicIpOnLaunch: false
       AvailabilityZone: !Select 
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -184,12 +173,11 @@ Resources:
       RouteTableId: !Ref PrivateRouteTableA
       SubnetId: !Ref PrivateSubnetA
   PrivateSubnetB:
-    DependsOn: PrivateRouteB
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref VPC
       CidrBlock: 10.1.4.0/24
-      MapPublicIpOnLaunch: true
+      MapPublicIpOnLaunch: false
       AvailabilityZone: !Select 
         - 1
         - Fn::GetAZs: !Ref 'AWS::Region'
@@ -232,32 +220,39 @@ Resources:
   ElasticsearchSecurityGroup:
       Type: "AWS::EC2::SecurityGroup"
       Properties:
-        GroupDescription: Allows internal data loading and public access to Elasticsearch.
+        GroupDescription: Allows only the Kibana proxy and Lambda functions to access Elasticsearch.
         VpcId: !Ref VPC
         SecurityGroupIngress:
-          # -
-          #   CidrIp: !Ref PublicCidr
-          #   IpProtocol: TCP
-          #   FromPort: 80
-          #   ToPort: 80
           -
-            CidrIp: 10.1.0.0/16
+            SourceSecurityGroupId: !Ref ProxyServerSecurityGroup
             IpProtocol: TCP
-            FromPort: 0
-            ToPort: 65535
+            FromPort: 80
+            ToPort: 80
+          -
+            SourceSecurityGroupId: !Ref ProxyServerSecurityGroup
+            IpProtocol: TCP
+            FromPort: 443
+            ToPort: 443
+          -
+            SourceSecurityGroupId: !Ref ESLambdaSecurityGroup
+            IpProtocol: TCP
+            FromPort: 80
+            ToPort: 80
+          -
+            SourceSecurityGroupId: !Ref ESLambdaSecurityGroup
+            IpProtocol: TCP
+            FromPort: 443
+            ToPort: 443
+
+  ESLambdaSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: Allows Lambda functions to reach the Elasticsearch domain from private subnets.
+      VpcId: !Ref VPC
 
   ####################################
   # ElasticSearch Reverse Proxy node #
   ####################################
-  ProxyEIP:
-    Type: "AWS::EC2::EIP"
-    Properties:
-      Domain: vpc
-  ProxyEIPAssociation:
-    Type: AWS::EC2::EIPAssociation
-    Properties:
-      AllocationId: !GetAtt ProxyEIP.AllocationId
-      InstanceId: !Ref ProxyServer
   ProxyServer:
     Type: AWS::EC2::Instance
     CreationPolicy:
@@ -293,7 +288,7 @@ Resources:
                               proxy_set_header Proxy-Connection "Keep-Alive";
                               proxy_set_header Authorization "";                       
                               proxy_pass https://${ESDom}/_plugin/kibana/;
-                              proxy_redirect https://${ESDom}/_plugin/kibana/ http://${PxyEIP}/kibana/;
+                              proxy_redirect https://${ESDom}/_plugin/kibana/ /kibana/;
                           }
                        
                             location ~ (/app/kibana|/app/timelion|/bundles|/es_admin|/plugins|/api|/ui|/elasticsearch) {
@@ -310,7 +305,7 @@ Resources:
                           }
                         }
                       }
-                  - { PxyEIP: !Ref ProxyEIP , ESDom: !GetAtt ElasticsearchDomain.DomainEndpoint }
+                  - { ESDom: !GetAtt ElasticsearchDomain.DomainEndpoint }
               group: root
               mode: '000400'
               owner: root
@@ -360,7 +355,7 @@ Resources:
     Properties:
       ImageId: !FindInMap [AWSRegionArch2AMI, !Ref 'AWS::Region', !FindInMap [AWSInstanceType2Arch, 't2.large', Arch]]      
       InstanceType: t2.large
-      SubnetId: !Ref PublicSubnetA
+      SubnetId: !Ref PrivateSubnetA
       SecurityGroupIds: 
         - !Ref ProxyServerSecurityGroup
       UserData:
@@ -373,9 +368,9 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       VpcId: !Ref VPC
-      GroupDescription: "Enable HTTP access via port 80 locked down to the load balancer + SSH access"
+      GroupDescription: "Enable VPC-only HTTP access to the Kibana reverse proxy"
       SecurityGroupIngress:
-        - CidrIp: !Ref PublicCidr
+        - CidrIp: 10.1.0.0/16
           FromPort: '80'
           IpProtocol: tcp
           ToPort: '80'
@@ -387,10 +382,7 @@ Outputs:
       !Join
         - ''
         - - 'http://'
-          - !Ref ProxyEIP
-  KibanaWhitelist:
-    Description: Public IPs Kibana is accessible from.
-    Value: !Ref PublicCidr
+          - !GetAtt ProxyServer.PrivateIp
   ESDomain:
     Description: ES Domain 
     Value: !GetAtt ElasticsearchDomain.DomainEndpoint
@@ -398,7 +390,7 @@ Outputs:
       Name: !Sub "${AWS::StackName}-DomainEndpoint"
   ESLambdaSecurityGroup:
     Description: ESLambdaSecurityGroup
-    Value: !Ref ElasticsearchSecurityGroup
+    Value: !Ref ESLambdaSecurityGroup
     Export:
       Name: !Sub "${AWS::StackName}-ESLambdaSecurityGroup"
   PrivateSubnetA:


### PR DESCRIPTION
## Context

Follow-up to #162 (merged). This applies the complete fix from the [advisory fork PR](https://github.com/aws/aws-health-tools-ghsa-xvcq-hx64-q4rj/pull/1) — moving from "restrict the access policy" to "eliminate the public access path entirely."

## Changes

### stepbystep template
- **Removed `PublicCidr` parameter** entirely — no more user-controlled internet exposure
- **Moved proxy to private subnet** (`PrivateSubnetA` instead of `PublicSubnetA`)
- **Removed `ProxyEIP`** — no public IP on the proxy
- **Proxy SG restricted to VPC CIDR** (`10.1.0.0/16`) instead of user CIDR
- **ES SG uses source security group refs** — only proxy SG and Lambda SG can reach ES (not broad CIDR)
- **Added `ESLambdaSecurityGroup`** — dedicated SG for Lambda functions
- **KibanaURL output** now shows private IP (accessible only from within VPC)
- **Removed circular dependency** — `PrivateSubnet` no longer has unnecessary `DependsOn` route

### Sydney demo template
- **Removed `PublicCidr` parameter**
- **ALB set to `Scheme: internal`** — not internet-facing
- **Added `ElasticsearchLoadBalancerSecurityGroup`** — VPC CIDR only
- **Added `ElasticsearchLambdaSecurityGroup`** — for Lambda access
- **Lambda functions** now use dedicated Lambda SG instead of ES SG
- **Removed `KibanaWhitelist` output**

### Documentation (both READMEs)
- Updated instructions to reflect private-only access ("from a host inside the VPC")
- Removed all `PublicCidr` parameter references
- Updated security guidance to recommend bastion/VPN for remote access

## Validation

- Both templates pass `aws cloudformation validate-template`
- No `PublicCidr` parameter in either template
- No `0.0.0.0/0` anywhere
- No internet-facing entry points remain
